### PR TITLE
Fix more test stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ vet:
 	@go vet -composites=false ./... && echo "Go vet analysis passed."
 
 clean:
-	@go clean -testcache ./...
+	@go clean -testcache
 
 sure: clean test examples vet
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,6 @@ vet:
 clean:
 	@go clean -testcache ./...
 
-sure: clean test examples contrib vet
+sure: clean test examples vet
 
-.PHONY: certgen test removecert examples vet contrib clean
+.PHONY: certgen test removecert examples vet clean

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,14 +15,15 @@ package config
 
 import (
 	"fmt"
-	"github.com/solarwinds/apm-go/internal/log"
-	"github.com/solarwinds/apm-go/internal/utils"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/solarwinds/apm-go/internal/log"
+	"github.com/solarwinds/apm-go/internal/utils"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -454,6 +455,7 @@ func TestInvalidConfigFile(t *testing.T) {
 	writers = append(writers, os.Stderr)
 
 	log.SetOutput(io.MultiWriter(writers...))
+	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -455,10 +455,12 @@ func TestInvalidConfigFile(t *testing.T) {
 	writers = append(writers, os.Stderr)
 
 	log.SetOutput(io.MultiWriter(writers...))
+	oldLevel := log.Level()
 	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)
+		log.SetLevel(oldLevel)
 	}()
 
 	ClearEnvs()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -455,10 +455,12 @@ func TestInvalidConfigFile(t *testing.T) {
 	writers = append(writers, os.Stderr)
 
 	log.SetOutput(io.MultiWriter(writers...))
+	oldLevel := log.Level
 	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)
+		log.SetLevel(oldLevel())
 	}()
 
 	ClearEnvs()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -455,12 +455,10 @@ func TestInvalidConfigFile(t *testing.T) {
 	writers = append(writers, os.Stderr)
 
 	log.SetOutput(io.MultiWriter(writers...))
-	oldLevel := log.Level
 	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)
-		log.SetLevel(oldLevel())
 	}()
 
 	ClearEnvs()

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -79,10 +79,12 @@ func TestConfiguredHostname(t *testing.T) {
 	writers = append(writers, &buf)
 
 	log.SetOutput(io.MultiWriter(writers...))
+	oldLevel := log.Level()
 	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)
+		log.SetLevel(oldLevel)
 	}()
 
 	var old string

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -79,12 +79,10 @@ func TestConfiguredHostname(t *testing.T) {
 	writers = append(writers, &buf)
 
 	log.SetOutput(io.MultiWriter(writers...))
-	oldLevel := log.Level
 	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)
-		log.SetLevel(oldLevel())
 	}()
 
 	var old string

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -14,15 +14,16 @@
 package host
 
 import (
-	"github.com/solarwinds/apm-go/internal/config"
-	"github.com/solarwinds/apm-go/internal/log"
-	"github.com/solarwinds/apm-go/internal/utils"
 	"io"
 	"net"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/solarwinds/apm-go/internal/config"
+	"github.com/solarwinds/apm-go/internal/log"
+	"github.com/solarwinds/apm-go/internal/utils"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,6 +79,7 @@ func TestConfiguredHostname(t *testing.T) {
 	writers = append(writers, &buf)
 
 	log.SetOutput(io.MultiWriter(writers...))
+	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -79,10 +79,12 @@ func TestConfiguredHostname(t *testing.T) {
 	writers = append(writers, &buf)
 
 	log.SetOutput(io.MultiWriter(writers...))
+	oldLevel := log.Level
 	log.SetLevel(log.INFO)
 
 	defer func() {
 		log.SetOutput(os.Stderr)
+		log.SetLevel(oldLevel())
 	}()
 
 	var old string


### PR DESCRIPTION
Fix more test stuff:

1. Add `log.SetLevel(log.INFO)` else tests may fail if `SW_APM_DEBUG_LEVEL` is set e.g. for other libraries on local.
2. Removes usage of non-existent `contrib` Make recipe.
3. Removes arg from call to `go test`, else errors with `go: clean -testcache cannot be used with package arguments`