### PR TITLE
NH-80156 Rm unnecessary reporterTypeServerless

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,9 +94,6 @@ type Config struct {
 	// The file path of the cert file for gRPC connection
 	TrustedPath string `yaml:"TrustedPath,omitempty" env:"SW_APM_TRUSTEDPATH"`
 
-	// The reporter type, ssl or none
-	ReporterType string `yaml:"ReporterType,omitempty" env:"SW_APM_REPORTER" default:"ssl"`
-
 	Sampling *SamplingConfig `yaml:"Sampling,omitempty"`
 
 	// Whether the domain should be prepended to the transaction name.
@@ -363,13 +360,6 @@ func (c *Config) validate() error {
 		log.Info(InvalidEnv("Ec2MetadataTimeout", strconv.Itoa(c.Ec2MetadataTimeout)))
 		t, _ := strconv.Atoi(getFieldDefaultValue(c, "Ec2MetadataTimeout"))
 		c.Ec2MetadataTimeout = t
-	}
-
-	c.ReporterType = strings.ToLower(strings.TrimSpace(c.ReporterType))
-
-	if ok := IsValidReporterType(c.ReporterType); !ok {
-		log.Info(InvalidEnv("ReporterType", c.ReporterType))
-		c.ReporterType = getFieldDefaultValue(c, "ReporterType")
 	}
 
 	if c.TransactionName != "" && !hasLambdaEnv() {
@@ -775,13 +765,6 @@ func (c *Config) GetTrustedPath() string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.TrustedPath
-}
-
-// GetReporterType returns the reporter type
-func (c *Config) GetReporterType() string {
-	c.RLock()
-	defer c.RUnlock()
-	return c.ReporterType
 }
 
 // GetTracingMode returns the local tracing mode

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -602,7 +602,8 @@ func TestTransactionName(t *testing.T) {
 	envs = []string{
 		"SW_APM_SERVICE_KEY=ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
 		"SW_APM_TRANSACTION_NAME=test_name",
-		"SW_APM_REPORTER=serverless",
+		"AWS_LAMBDA_FUNCTION_NAME=my_function",
+		"LAMBDA_TASK_ROOT=some_path",
 	}
 	SetEnvs(envs)
 	c = NewConfig()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,10 +132,9 @@ func TestConfigInit(t *testing.T) {
 	c.reset()
 
 	defaultC := Config{
-		Collector:    defaultSSLCollector,
-		ServiceKey:   "",
-		TrustedPath:  "",
-		ReporterType: "ssl",
+		Collector:   defaultSSLCollector,
+		ServiceKey:  "",
+		TrustedPath: "",
 		Sampling: &SamplingConfig{
 			TracingMode:           "enabled",
 			tracingModeConfigured: false,
@@ -253,10 +252,9 @@ func TestEnvsLoading(t *testing.T) {
 	SetEnvs(envs)
 
 	envConfig := Config{
-		Collector:    "collector.test.com",
-		ServiceKey:   "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
-		TrustedPath:  "/collector.crt",
-		ReporterType: "ssl",
+		Collector:   "collector.test.com",
+		ServiceKey:  "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
+		TrustedPath: "/collector.crt",
 		Sampling: &SamplingConfig{
 			TracingMode:           "disabled",
 			tracingModeConfigured: true,
@@ -300,10 +298,9 @@ func TestEnvsLoading(t *testing.T) {
 
 func TestYamlConfig(t *testing.T) {
 	yamlConfig := Config{
-		Collector:    "yaml.test.com",
-		ServiceKey:   "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189218:go",
-		TrustedPath:  "/yaml-collector.crt",
-		ReporterType: "ssl",
+		Collector:   "yaml.test.com",
+		ServiceKey:  "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189218:go",
+		TrustedPath: "/yaml-collector.crt",
 		Sampling: &SamplingConfig{
 			TracingMode:           "disabled",
 			tracingModeConfigured: true,
@@ -383,10 +380,9 @@ func TestYamlConfig(t *testing.T) {
 	os.Setenv("SW_APM_CONFIG_FILE", "/tmp/solarwinds-apm-config.yaml")
 
 	envConfig := Config{
-		Collector:    "collector.test.com",
-		ServiceKey:   "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
-		TrustedPath:  "/collector.crt",
-		ReporterType: "ssl",
+		Collector:   "collector.test.com",
+		ServiceKey:  "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
+		TrustedPath: "/collector.crt",
 		Sampling: &SamplingConfig{
 			TracingMode:           "disabled",
 			tracingModeConfigured: true,
@@ -496,10 +492,9 @@ func TestInvalidConfig(t *testing.T) {
 	}()
 
 	invalid := Config{
-		Collector:    "",
-		ServiceKey:   "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
-		TrustedPath:  "",
-		ReporterType: "invalid",
+		Collector:   "",
+		ServiceKey:  "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
+		TrustedPath: "",
 		Sampling: &SamplingConfig{
 			TracingMode:           "disabled",
 			tracingModeConfigured: true,
@@ -531,9 +526,6 @@ func TestInvalidConfig(t *testing.T) {
 
 	assert.Equal(t, defaultSSLCollector, invalid.Collector)
 	assert.Contains(t, buf.String(), "invalid env, discarded - Collector:", buf.String())
-
-	assert.Equal(t, "ssl", invalid.ReporterType)
-	assert.Contains(t, buf.String(), "invalid env, discarded - ReporterType:", buf.String())
 
 	assert.Equal(t, 1000, invalid.Ec2MetadataTimeout)
 	assert.Contains(t, buf.String(), "invalid env, discarded - Ec2MetadataTimeout:", buf.String())

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -44,11 +44,6 @@ const (
 	invalidCharReplacer = ""
 )
 
-// reporter types
-const (
-	reporterTypeSSL = "ssl"
-)
-
 var (
 	// IsValidServiceKey verifies if the service key is a valid one.
 	// A valid service key is something like 'service_token:service_name'.
@@ -99,12 +94,6 @@ func IsValidHost(host string) bool {
 func IsValidFile(file string) bool {
 	// TODO
 	return true
-}
-
-// IsValidReporterType checks if the reporter type is valid.
-func IsValidReporterType(t string) bool {
-	t = strings.ToLower(strings.TrimSpace(t))
-	return t == reporterTypeSSL
 }
 
 // IsValidEc2MetadataTimeout checks if the timeout is within the designated range

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -46,8 +46,7 @@ const (
 
 // reporter types
 const (
-	reporterTypeSSL        = "ssl"
-	reporterTypeServerless = "serverless"
+	reporterTypeSSL = "ssl"
 )
 
 var (
@@ -105,7 +104,7 @@ func IsValidFile(file string) bool {
 // IsValidReporterType checks if the reporter type is valid.
 func IsValidReporterType(t string) bool {
 	t = strings.ToLower(strings.TrimSpace(t))
-	return t == reporterTypeSSL || t == reporterTypeServerless
+	return t == reporterTypeSSL
 }
 
 // IsValidEc2MetadataTimeout checks if the timeout is within the designated range

--- a/internal/config/validators_test.go
+++ b/internal/config/validators_test.go
@@ -77,16 +77,6 @@ func TestIsValidTracingMode(t *testing.T) {
 	assert.Equal(t, false, IsValidTracingMode("NEVER"))
 }
 
-func TestIsValidReporterType(t *testing.T) {
-	assert.Equal(t, false, IsValidReporterType("udp"))
-	assert.Equal(t, true, IsValidReporterType("ssl"))
-	assert.Equal(t, false, IsValidReporterType("Udp"))
-	assert.Equal(t, false, IsValidReporterType("xxx"))
-	assert.Equal(t, false, IsValidReporterType(""))
-	assert.Equal(t, false, IsValidReporterType("udpabc"))
-	assert.Equal(t, false, IsValidReporterType("serverless"))
-}
-
 func TestConverters(t *testing.T) {
 	assert.Equal(t, DisabledTracingMode, NormalizeTracingMode("disabled"))
 	assert.Equal(t, DisabledTracingMode, NormalizeTracingMode("never"))

--- a/internal/config/validators_test.go
+++ b/internal/config/validators_test.go
@@ -84,7 +84,7 @@ func TestIsValidReporterType(t *testing.T) {
 	assert.Equal(t, false, IsValidReporterType("xxx"))
 	assert.Equal(t, false, IsValidReporterType(""))
 	assert.Equal(t, false, IsValidReporterType("udpabc"))
-	assert.Equal(t, true, IsValidReporterType("serverless"))
+	assert.Equal(t, false, IsValidReporterType("serverless"))
 }
 
 func TestConverters(t *testing.T) {

--- a/internal/config/wrappers.go
+++ b/internal/config/wrappers.go
@@ -29,9 +29,6 @@ var GetServiceKey = conf.GetServiceKey
 // GetTrustedPath is a wrapper to the method of the global config
 var GetTrustedPath = conf.GetTrustedPath
 
-// GetReporterType is a wrapper to the method of the global config
-var GetReporterType = conf.GetReporterType
-
 // GetTracingMode is a wrapper to the method of the global config
 var GetTracingMode = conf.GetTracingMode
 

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -84,19 +84,13 @@ func Start(rsrc *resource.Resource, registry interface{}, o oboe.Oboe) (Reporter
 }
 
 func initReporter(r *resource.Resource, registry metrics.LegacyRegistry, o oboe.Oboe) Reporter {
-	var rt string
-	if !config.GetEnabled() {
-		log.Warning("SolarWinds Observability APM agent is disabled.")
-		rt = "none"
-	} else {
-		rt = "ssl"
-	}
 	otelServiceName := ""
 	if sn, ok := r.Set().Value(semconv.ServiceNameKey); ok {
 		otelServiceName = strings.TrimSpace(sn.AsString())
 		state.SetServiceName(otelServiceName)
 	}
-	if rt == "none" {
+	if !config.GetEnabled() {
+		log.Warning("SolarWinds Observability APM agent is disabled.")
 		return newNullReporter()
 	}
 	return newGRPCReporter(otelServiceName, registry, o)

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -17,6 +17,9 @@ package reporter
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/solarwinds/apm-go/internal/config"
 	"github.com/solarwinds/apm-go/internal/log"
@@ -29,8 +32,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
-	"strings"
-	"time"
 )
 
 // defines what methods a Reporter should offer (internal to Reporter package)
@@ -88,7 +89,7 @@ func initReporter(r *resource.Resource, registry metrics.LegacyRegistry, o oboe.
 		log.Warning("SolarWinds Observability APM agent is disabled.")
 		rt = "none"
 	} else {
-		rt = config.GetReporterType()
+		rt = "ssl"
 	}
 	otelServiceName := ""
 	if sn, ok := r.Set().Value(semconv.ServiceNameKey); ok {


### PR DESCRIPTION
Looking at changes from 3 years ago ([reporter mode check in a single point · solarwinds/apm-go@edb7684](https://github.com/solarwinds/apm-go/commit/edb7684bd49b2a5703e715c219525c2e6da78904)) `reporterTypeServerless` is being set then used for transaction name and service key check in config. But actual ReporterType ends up being one of `ssl` or none. We can do those config checks by directly checking the lambda env vars and not setting type ReporterType `serverless` anymore.