### PR TITLE
NH-78295 Add settings FileBasedWatcher

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,8 +340,8 @@ const (
 	may be different from your setting.`
 )
 
-// HasLambdaEnv checks if the AWS Lambda env var is set.
-func HasLambdaEnv() bool {
+// hasLambdaEnv checks if the AWS Lambda env var is set.
+func hasLambdaEnv() bool {
 	return os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" && os.Getenv("LAMBDA_TASK_ROOT") != ""
 }
 
@@ -362,12 +362,12 @@ func (c *Config) validate() error {
 		c.Ec2MetadataTimeout = t
 	}
 
-	if c.TransactionName != "" && !HasLambdaEnv() {
+	if c.TransactionName != "" && !hasLambdaEnv() {
 		log.Info(InvalidEnv("TransactionName", c.TransactionName))
 		c.TransactionName = getFieldDefaultValue(c, "TransactionName")
 	}
 
-	if !HasLambdaEnv() {
+	if !hasLambdaEnv() {
 		if c.ServiceKey != "" {
 			c.ServiceKey = ToServiceKey(c.ServiceKey)
 			if ok := IsValidServiceKey(c.ServiceKey); !ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,8 +340,8 @@ const (
 	may be different from your setting.`
 )
 
-// hasLambdaEnv checks if the AWS Lambda env var is set.
-func hasLambdaEnv() bool {
+// HasLambdaEnv checks if the AWS Lambda env var is set.
+func HasLambdaEnv() bool {
 	return os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" && os.Getenv("LAMBDA_TASK_ROOT") != ""
 }
 
@@ -362,12 +362,12 @@ func (c *Config) validate() error {
 		c.Ec2MetadataTimeout = t
 	}
 
-	if c.TransactionName != "" && !hasLambdaEnv() {
+	if c.TransactionName != "" && !HasLambdaEnv() {
 		log.Info(InvalidEnv("TransactionName", c.TransactionName))
 		c.TransactionName = getFieldDefaultValue(c, "TransactionName")
 	}
 
-	if !hasLambdaEnv() {
+	if !HasLambdaEnv() {
 		if c.ServiceKey != "" {
 			c.ServiceKey = ToServiceKey(c.ServiceKey)
 			if ok := IsValidServiceKey(c.ServiceKey); !ok {

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -15,53 +15,74 @@
 package oboe
 
 import (
+	"encoding/binary"
 	stdlog "log"
 	"time"
+
+	"github.com/coocood/freecache"
 )
 
 const (
-	tick     = 10
-	tickUnit = time.Second
+	cacheSize            = 5 * 1024 * 1024 // 5 MB
+	settingsCheckSeconds = 10
 )
 
+var keyTtl []byte = []byte("ttl")
 var exit = make(chan bool, 1)
 
 type FileBasedWatcher interface {
-	UpdateSettingFromFile()
 	Start()
 	Stop()
 }
 
 // NewFileBasedWatcher returns a FileBasedWatcher that periodically
-// does oboe.UpdateSetting using values from a settings JSON file.
+// does oboe.UpdateSetting using values from a settings JSON file,
+// if cached settings have not yet expired.
 func NewFileBasedWatcher(oboe *Oboe) FileBasedWatcher {
 	return &fileBasedWatcher{
 		*oboe,
+		*freecache.NewCache(cacheSize),
 	}
 }
 
 type fileBasedWatcher struct {
-	o Oboe
+	o             Oboe
+	settingsCache freecache.Cache
 }
 
-func (fbw *fileBasedWatcher) UpdateSettingFromFile() {
+// updateCacheFromFile sets "ttl" as byte representation of ttl in seconds.
+func (fbw *fileBasedWatcher) updateCacheFromFile(sl *settingLambdaNormalized) {
+	ttlBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(ttlBytes, uint64(sl.ttl))
+	fbw.settingsCache.Set(keyTtl, ttlBytes, int(sl.ttl))
+}
+
+// updateSettingFromFile updates oboe settings using normalized settings from file.
+func (fbw *fileBasedWatcher) updateSettingFromFile(sl *settingLambdaNormalized) {
+	fbw.o.UpdateSetting(
+		sl.sType,
+		sl.layer,
+		sl.flags,
+		sl.value,
+		sl.ttl,
+		sl.args,
+	)
+}
+
+func (fbw *fileBasedWatcher) updateSettingAndCacheFromFile() {
 	settingLambda, err := newSettingLambdaFromFile()
 	if err != nil {
 		stdlog.Fatalf("Could not update setting from file: %s", err)
 		return
 	}
-	fbw.o.UpdateSetting(
-		settingLambda.sType,
-		settingLambda.layer,
-		settingLambda.flags,
-		settingLambda.value,
-		settingLambda.ttl,
-		settingLambda.args,
-	)
+	fbw.updateSettingFromFile(settingLambda)
+	fbw.updateCacheFromFile(settingLambda)
 }
 
+// Start runs a ticker that checks settings expiry from cache
+// and, if expired, updates cache and oboe settings.
 func (fbw *fileBasedWatcher) Start() {
-	ticker := time.NewTicker(tick * tickUnit)
+	ticker := time.NewTicker(settingsCheckSeconds * time.Second)
 	go func() {
 		defer ticker.Stop()
 		for {
@@ -69,8 +90,19 @@ func (fbw *fileBasedWatcher) Start() {
 			case <-exit:
 				return
 			case <-ticker.C:
-				stdlog.Print("Updating settings from file.")
-				fbw.UpdateSettingFromFile()
+				_, expireAt, err := fbw.settingsCache.GetWithExpiration(keyTtl)
+				if err != nil {
+					stdlog.Fatalf("There was an issue with settingsCache: %s", err)
+					// TODO: disable APM Go
+				} else {
+					// If cached settings expired, update cache and
+					// and update oboe settings
+					remainingTime := expireAt - uint32(time.Now().Unix())
+					if remainingTime <= 0 {
+						stdlog.Print("Updating settings from file.")
+						fbw.updateSettingAndCacheFromFile()
+					}
+				}
 			}
 		}
 	}()

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -65,14 +65,15 @@ func (fbw *fileBasedWatcher) updateCacheFromFile(sl *settingLambdaNormalized) {
 
 // updateSettingFromFile updates oboe settings using normalized settings from file.
 func (fbw *fileBasedWatcher) updateSettingFromFile(sl *settingLambdaNormalized) {
-	fbw.o.UpdateSetting(
-		sl.sType,
-		sl.layer,
-		sl.flags,
-		sl.value,
-		sl.ttl,
-		sl.args,
-	)
+	stdlog.Printf("TODO: Implement updateSettingFromFile. Received normalized settings %v", sl)
+	// fbw.o.UpdateSetting(
+	// 	sl.sType,
+	// 	sl.layer,
+	// 	sl.flags,
+	// 	sl.value,
+	// 	sl.ttl,
+	// 	sl.args,
+	// )
 }
 
 func (fbw *fileBasedWatcher) updateSettingAndCacheFromFile() {
@@ -99,7 +100,7 @@ func (fbw *fileBasedWatcher) Start() {
 				// expired values are Not Found
 				_, notFound := fbw.settingsCache.Get(keyTtl)
 				if notFound != nil {
-					stdlog.Printf("Updating settings and cache from file.")
+					stdlog.Printf("Checking settings from file.")
 					fbw.updateSettingAndCacheFromFile()
 				}
 			}

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -15,20 +15,14 @@
 package oboe
 
 import (
-	"encoding/binary"
 	stdlog "log"
-	"math"
 	"time"
-
-	"github.com/coocood/freecache"
 )
 
 const (
-	cacheSize            = 100 * 1024 // 100 kB
 	settingsCheckSeconds = 10
 )
 
-var keyTtl []byte = []byte("ttl")
 var exit = make(chan bool, 1)
 
 type FileBasedWatcher interface {
@@ -37,53 +31,28 @@ type FileBasedWatcher interface {
 }
 
 // NewFileBasedWatcher returns a FileBasedWatcher that periodically
-// does oboe.UpdateSetting using values from a settings JSON file,
-// if cached settings have not yet expired.
+// reads lambda settings from file
 func NewFileBasedWatcher(oboe *Oboe) FileBasedWatcher {
 	return &fileBasedWatcher{
 		*oboe,
-		*freecache.NewCache(cacheSize),
 	}
 }
 
 type fileBasedWatcher struct {
-	o             Oboe
-	settingsCache freecache.Cache
+	o Oboe
 }
 
-// updateCacheFromFile sets "ttl" as byte representation of ttl in seconds.
-func (fbw *fileBasedWatcher) updateCacheFromFile(sl *settingLambdaNormalized) {
-	ttlBits := math.Float64bits(float64(sl.ttl))
-	ttlBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(ttlBytes, ttlBits)
-	err := fbw.settingsCache.Set(keyTtl, ttlBytes, int(sl.ttl))
-	if err != nil {
-		stdlog.Fatalf("There was an issue with setting settingsCache: %s", err)
-		// TODO: disable APM Go
-	}
-}
-
-// updateSettingFromFile updates oboe settings using normalized settings from file.
-func (fbw *fileBasedWatcher) updateSettingFromFile(sl *settingLambdaNormalized) {
-	stdlog.Printf("TODO: Implement updateSettingFromFile. Received normalized settings %v", sl)
-	// fbw.o.UpdateSetting(
-	// 	sl.sType,
-	// 	sl.layer,
-	// 	sl.flags,
-	// 	sl.value,
-	// 	sl.ttl,
-	// 	sl.args,
-	// )
-}
-
-func (fbw *fileBasedWatcher) updateSettingAndCacheFromFile() {
+// readSettingFromFile parses, normalizes, and print settings from file
+func (fbw *fileBasedWatcher) readSettingFromFile() {
 	settingLambda, err := newSettingLambdaFromFile()
 	if err != nil {
-		stdlog.Fatalf("Could not update setting from file: %s", err)
+		stdlog.Fatalf("Could not read setting from file: %s", err)
 		return
 	}
-	fbw.updateSettingFromFile(settingLambda)
-	fbw.updateCacheFromFile(settingLambda)
+	stdlog.Printf(
+		"Got lambda settings from file:\n%v",
+		settingLambda,
+	)
 }
 
 // Start runs a ticker that checks settings expiry from cache
@@ -97,12 +66,7 @@ func (fbw *fileBasedWatcher) Start() {
 			case <-exit:
 				return
 			case <-ticker.C:
-				// expired values are Not Found
-				_, notFound := fbw.settingsCache.Get(keyTtl)
-				if notFound != nil {
-					stdlog.Printf("Checking settings from file.")
-					fbw.updateSettingAndCacheFromFile()
-				}
+				fbw.readSettingFromFile()
 			}
 		}
 	}()

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -54,7 +54,11 @@ type fileBasedWatcher struct {
 func (fbw *fileBasedWatcher) updateCacheFromFile(sl *settingLambdaNormalized) {
 	ttlBytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(ttlBytes, uint64(sl.ttl))
-	fbw.settingsCache.Set(keyTtl, ttlBytes, int(sl.ttl))
+	err := fbw.settingsCache.Set(keyTtl, ttlBytes, int(sl.ttl))
+	if err != nil {
+		stdlog.Fatalf("There was an issue with setting settingsCache: %s", err)
+		// TODO: disable APM Go
+	}
 }
 
 // updateSettingFromFile updates oboe settings using normalized settings from file.
@@ -92,7 +96,7 @@ func (fbw *fileBasedWatcher) Start() {
 			case <-ticker.C:
 				_, expireAt, err := fbw.settingsCache.GetWithExpiration(keyTtl)
 				if err != nil {
-					stdlog.Fatalf("There was an issue with settingsCache: %s", err)
+					stdlog.Fatalf("There was an issue with getting settingsCache: %s", err)
 					// TODO: disable APM Go
 				} else {
 					// If cached settings expired, update cache and

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	cacheSize            = 5 * 1024 * 1024 // 5 MB
+	cacheSize            = 100 * 1024 // 100 kB
 	settingsCheckSeconds = 10
 )
 

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -15,8 +15,9 @@
 package oboe
 
 import (
-	stdlog "log"
 	"time"
+
+	"github.com/solarwinds/apm-go/internal/log"
 )
 
 const (
@@ -46,10 +47,10 @@ type fileBasedWatcher struct {
 func (fbw *fileBasedWatcher) readSettingFromFile() {
 	settingLambda, err := newSettingLambdaFromFile()
 	if err != nil {
-		stdlog.Fatalf("Could not read setting from file: %s", err)
+		log.Errorf("Could not read setting from file: %s", err)
 		return
 	}
-	stdlog.Printf(
+	log.Debugf(
 		"Got lambda settings from file:\n%v",
 		settingLambda,
 	)
@@ -73,6 +74,6 @@ func (fbw *fileBasedWatcher) Start() {
 }
 
 func (fbw *fileBasedWatcher) Stop() {
-	stdlog.Print("Stopping settings file watcher.")
+	log.Info("Stopping settings file watcher.")
 	exit <- true
 }

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -1,0 +1,69 @@
+// © 2024 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oboe
+
+import (
+	stdlog "log"
+	"time"
+)
+
+const (
+	tick     = 10
+	tickUnit = time.Second
+)
+
+type FileBasedWatcher interface {
+	UpdateSettingFromFile()
+	Start()
+	Stop()
+}
+
+func NewFileBasedWatcher(oboe *Oboe) FileBasedWatcher {
+	return &fileBasedWatcher{
+		*oboe,
+		time.NewTicker(tick * tickUnit),
+	}
+}
+
+type fileBasedWatcher struct {
+	o      Oboe
+	ticker *time.Ticker
+}
+
+func (fbw *fileBasedWatcher) UpdateSettingFromFile() {
+	settingLambda, err := newSettingLambdaFromFile()
+	if err != nil {
+		stdlog.Fatalf("Could not update setting from file: %s", err)
+		return
+	}
+	fbw.o.UpdateSetting(
+		settingLambda.sType,
+		settingLambda.layer,
+		settingLambda.flags,
+		settingLambda.value,
+		settingLambda.ttl,
+		settingLambda.args,
+	)
+}
+
+func (fbw *fileBasedWatcher) Start() {
+	for range fbw.ticker.C {
+		fbw.UpdateSettingFromFile()
+	}
+}
+
+func (fbw *fileBasedWatcher) Stop() {
+	fbw.ticker.Stop()
+}

--- a/internal/oboe/file_watcher.go
+++ b/internal/oboe/file_watcher.go
@@ -32,6 +32,8 @@ type FileBasedWatcher interface {
 	Stop()
 }
 
+// NewFileBasedWatcher returns a FileBasedWatcher that periodically
+// does oboe.UpdateSetting using values from a settings JSON file.
 func NewFileBasedWatcher(oboe *Oboe) FileBasedWatcher {
 	return &fileBasedWatcher{
 		*oboe,

--- a/internal/oboe/oboe.go
+++ b/internal/oboe/oboe.go
@@ -50,7 +50,7 @@ const (
 
 type Oboe interface {
 	UpdateSetting(sType int32, layer string, flags []byte, value int64, ttl int64, args map[string][]byte)
-	UpdateSettingFromFile() bool
+	UpdateSettingFromFile()
 	StartSettingTicker()
 	StopSettingTicker()
 	CheckSettingsTimeout()
@@ -256,12 +256,11 @@ func (o *oboe) UpdateSetting(sType int32, layer string, flags []byte, value int6
 	o.Unlock()
 }
 
-// UpdateSettingFromFile returns bool if reading file and update successful
-func (o *oboe) UpdateSettingFromFile() bool {
+func (o *oboe) UpdateSettingFromFile() {
 	settingLambda, err := newSettingLambdaFromFile()
 	if err != nil {
 		stdlog.Fatalf("Could not update setting from file: %s", err)
-		return false
+		return
 	}
 
 	var sType int = 1     // always DEFAULT_SAMPLE_RATE
@@ -299,8 +298,6 @@ func (o *oboe) UpdateSettingFromFile() bool {
 	o.Lock()
 	o.settings[key] = merged
 	o.Unlock()
-
-	return true
 }
 
 func (o *oboe) StartSettingTicker() {

--- a/internal/oboe/oboe.go
+++ b/internal/oboe/oboe.go
@@ -262,42 +262,14 @@ func (o *oboe) UpdateSettingFromFile() {
 		stdlog.Fatalf("Could not update setting from file: %s", err)
 		return
 	}
-
-	var sType int = 1     // always DEFAULT_SAMPLE_RATE
-	var layer string = "" // not set since type is always DEFAULT_SAMPLE_RATE
-
-	ns := newOboeSettings()
-	ns.source = settingType(sType).toSampleSource()
-	ns.layer = layer
-
-	ns.timestamp = time.Unix(int64(settingLambda.Timestamp), 0)
-	ns.flags = flagStringToBin(settingLambda.Flags)
-	ns.originalFlags = flagStringToBin(settingLambda.Flags)
-	ns.value = adjustSampleRate(int64(settingLambda.Value))
-	ns.ttl = int64(settingLambda.Ttl)
-
-	rate := float64(settingLambda.Arguments.BucketRate)
-	capacity := float64(settingLambda.Arguments.BucketCapacity)
-	ns.bucket.setRateCap(rate, capacity)
-
-	tRelaxedRate := float64(settingLambda.Arguments.TriggerRelaxedBucketRate)
-	tRelaxedCapacity := float64(settingLambda.Arguments.TriggerRelaxedBucketCapacity)
-	ns.triggerTraceRelaxedBucket.setRateCap(tRelaxedRate, tRelaxedCapacity)
-
-	tStrictRate := float64(settingLambda.Arguments.TriggerStrictBucketRate)
-	tStrictCapacity := float64(settingLambda.Arguments.TriggerStrictBucketCapacity)
-	ns.triggerTraceStrictBucket.setRateCap(tStrictRate, tStrictCapacity)
-
-	merged := mergeLocalSetting(ns)
-
-	key := settingKey{
-		sType: settingType(sType),
-		layer: layer,
-	}
-
-	o.Lock()
-	o.settings[key] = merged
-	o.Unlock()
+	o.UpdateSetting(
+		settingLambda.sType,
+		settingLambda.layer,
+		settingLambda.flags,
+		settingLambda.value,
+		settingLambda.ttl,
+		settingLambda.args,
+	)
 }
 
 func (o *oboe) StartSettingTicker() {

--- a/internal/oboe/oboe.go
+++ b/internal/oboe/oboe.go
@@ -285,23 +285,22 @@ func (o *oboe) UpdateSettingFromFile() {
 	ns.source = settingType(sType).toSampleSource()
 	ns.layer = layer
 
-	// TODO get these from settingLambda; placeholders from example file for now
-	ns.timestamp = time.Now()
-	ns.flags = flagStringToBin("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE")
-	ns.originalFlags = flagStringToBin("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE")
-	ns.value = adjustSampleRate(1000000)
-	ns.ttl = 120
+	ns.timestamp = time.Unix(int64(settingLambda.Timestamp), 0)
+	ns.flags = flagStringToBin(settingLambda.Flags)
+	ns.originalFlags = flagStringToBin(settingLambda.Flags)
+	ns.value = adjustSampleRate(int64(settingLambda.Value))
+	ns.ttl = int64(settingLambda.Ttl)
 
-	rate := float64(0.374)
-	capacity := float64(6.8)
+	rate := float64(settingLambda.Arguments.BucketRate)
+	capacity := float64(settingLambda.Arguments.BucketCapacity)
 	ns.bucket.setRateCap(rate, capacity)
 
-	tRelaxedRate := float64(1)
-	tRelaxedCapacity := float64(20)
+	tRelaxedRate := float64(settingLambda.Arguments.TriggerRelaxedBucketRate)
+	tRelaxedCapacity := float64(settingLambda.Arguments.TriggerRelaxedBucketCapacity)
 	ns.triggerTraceRelaxedBucket.setRateCap(tRelaxedRate, tRelaxedCapacity)
 
-	tStrictRate := float64(0.1)
-	tStrictCapacity := float64(6)
+	tStrictRate := float64(settingLambda.Arguments.TriggerStrictBucketRate)
+	tStrictCapacity := float64(settingLambda.Arguments.TriggerStrictBucketCapacity)
 	ns.triggerTraceStrictBucket.setRateCap(tStrictRate, tStrictCapacity)
 
 	merged := mergeLocalSetting(ns)

--- a/internal/oboe/oboe.go
+++ b/internal/oboe/oboe.go
@@ -50,7 +50,7 @@ const (
 
 type Oboe interface {
 	UpdateSetting(sType int32, layer string, flags []byte, value int64, ttl int64, args map[string][]byte)
-	UpdateSettingFromFile()
+	UpdateSettingFromFile() bool
 	StartSettingTicker()
 	StopSettingTicker()
 	CheckSettingsTimeout()
@@ -256,11 +256,12 @@ func (o *oboe) UpdateSetting(sType int32, layer string, flags []byte, value int6
 	o.Unlock()
 }
 
-func (o *oboe) UpdateSettingFromFile() {
+// UpdateSettingFromFile returns bool if reading file and update successful
+func (o *oboe) UpdateSettingFromFile() bool {
 	settingLambda, err := newSettingLambdaFromFile()
 	if err != nil {
 		stdlog.Fatalf("Could not update setting from file: %s", err)
-		return
+		return false
 	}
 
 	var sType int = 1     // always DEFAULT_SAMPLE_RATE
@@ -298,6 +299,8 @@ func (o *oboe) UpdateSettingFromFile() {
 	o.Lock()
 	o.settings[key] = merged
 	o.Unlock()
+
+	return true
 }
 
 func (o *oboe) StartSettingTicker() {

--- a/internal/oboe/oboe.go
+++ b/internal/oboe/oboe.go
@@ -16,13 +16,10 @@ package oboe
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	stdlog "log"
 	"math"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -260,28 +257,16 @@ func (o *oboe) UpdateSetting(sType int32, layer string, flags []byte, value int6
 }
 
 func (o *oboe) UpdateSettingFromFile() {
-	ns := newOboeSettings()
-
-	// TODO tracing mode disabled if cannot open/parse/get all settings
-	settingFile, err := os.Open("/tmp/solarwinds-apm-settings.json")
+	settingLambda, err := newSettingLambdaFromFile()
 	if err != nil {
-		stdlog.Fatal("Could not open Lambda settings file")
+		stdlog.Fatalf("Could not update setting from file: %s", err)
+		return
 	}
-	settingBytes, err := io.ReadAll(settingFile)
-	if err != nil {
-		stdlog.Fatal("Could not read Lambda settings file")
-	}
-	// Settings file is an array with a single settings object
-	var settingLambdas []settingLambda
-	json.Unmarshal(settingBytes, &settingLambdas)
-	var settingLambda settingLambda = settingLambdas[0]
-	// debug
-	stdlog.Printf("settingLambda: %v", settingLambda)
-	stdlog.Printf("settingLambda.Arguments: %v", settingLambda.Arguments)
 
 	var sType int = 1     // always DEFAULT_SAMPLE_RATE
 	var layer string = "" // not set since type is always DEFAULT_SAMPLE_RATE
 
+	ns := newOboeSettings()
 	ns.source = settingType(sType).toSampleSource()
 	ns.layer = layer
 

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -15,14 +15,18 @@
 package oboe
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"io"
 	stdlog "log"
+	"math"
 	"os"
+
+	"github.com/solarwinds/apm-go/internal/constants"
 )
 
-type settingLambda struct {
+type settingLambdaFromFile struct {
 	Arguments *settingArguments `json:"arguments"`
 	Flags     string            `json:"flags"`
 	Layer     string            `json:"layer"`
@@ -35,15 +39,54 @@ type settingLambda struct {
 type settingArguments struct {
 	BucketCapacity               float64 `json:"BucketCapacity"`
 	BucketRate                   float64 `json:"BucketRate"`
-	MetricsFlushInterval         int64   `json:"MetricsFlushInterval"`
+	MetricsFlushInterval         float64 `json:"MetricsFlushInterval"`
 	TriggerRelaxedBucketCapacity float64 `json:"TriggerRelaxedBucketCapacity"`
 	TriggerRelaxedBucketRate     float64 `json:"TriggerRelaxedBucketRate"`
 	TriggerStrictBucketCapacity  float64 `json:"TriggerStrictBucketCapacity"`
 	TriggerStrictBucketRate      float64 `json:"TriggerStrictBucketRate"`
 }
 
-func newSettingLambdaFromFile() (*settingLambda, error) {
-	// TODO tracing mode disabled if cannot open/parse/get all settings
+type settingLambdaNormalized struct {
+	sType int32
+	layer string
+	flags []byte
+	value int64
+	ttl   int64
+	args  map[string][]byte
+}
+
+// TODO(?): consolidate with internal/oboetestutils/oboe.go argsToMap
+func floatToBytes(float float64) []byte {
+	bytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bytes, math.Float64bits(float))
+	return bytes
+}
+
+func newSettingLambdaNormalized(fromFile *settingLambdaFromFile) *settingLambdaNormalized {
+	flags := []byte(fromFile.Flags)
+
+	args := make(map[string][]byte)
+	args[constants.KvBucketCapacity] = floatToBytes(fromFile.Arguments.BucketCapacity)
+	args[constants.KvBucketRate] = floatToBytes(fromFile.Arguments.BucketRate)
+	args[constants.KvMetricsFlushInterval] = floatToBytes(fromFile.Arguments.MetricsFlushInterval)
+	args[constants.KvTriggerTraceRelaxedBucketCapacity] = floatToBytes(fromFile.Arguments.TriggerRelaxedBucketCapacity)
+	args[constants.KvTriggerTraceRelaxedBucketRate] = floatToBytes(fromFile.Arguments.TriggerRelaxedBucketRate)
+	args[constants.KvTriggerTraceStrictBucketCapacity] = floatToBytes(fromFile.Arguments.TriggerStrictBucketCapacity)
+	args[constants.KvTriggerTraceStrictBucketRate] = floatToBytes(fromFile.Arguments.TriggerStrictBucketRate)
+
+	settingNorm := settingLambdaNormalized{
+		1,  // always DEFAULT_SAMPLE_RATE
+		"", // not set since type is always DEFAULT_SAMPLE_RATE
+		flags,
+		int64(fromFile.Value),
+		int64(fromFile.Ttl),
+		args,
+	}
+
+	return &settingNorm
+}
+
+func newSettingLambdaFromFile() (*settingLambdaNormalized, error) {
 	settingFile, err := os.Open("/tmp/solarwinds-apm-settings.json")
 	if err != nil {
 		return nil, err
@@ -53,7 +96,7 @@ func newSettingLambdaFromFile() (*settingLambda, error) {
 		return nil, err
 	}
 	// Settings file should be an array with a single settings object
-	var settingLambdas []settingLambda
+	var settingLambdas []settingLambdaFromFile
 	if err := json.Unmarshal(settingBytes, &settingLambdas); err != nil {
 		return nil, err
 	}
@@ -61,10 +104,13 @@ func newSettingLambdaFromFile() (*settingLambda, error) {
 		return nil, errors.New("settings file is incorrectly formatted")
 	}
 
-	var settingLambda settingLambda = settingLambdas[0]
+	var settingLambda settingLambdaFromFile = settingLambdas[0]
 	// tmp: debug
 	stdlog.Printf("settingLambda: %v", settingLambda)
 	stdlog.Printf("settingLambda.Arguments: %v", settingLambda.Arguments)
 
-	return &settingLambda, nil
+	var settingLambdaNormalized = newSettingLambdaNormalized(&settingLambda)
+	// tmp: debug
+	stdlog.Printf("settingLambdaNormalized: %v", settingLambdaNormalized)
+	return settingLambdaNormalized, nil
 }

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -43,6 +43,7 @@ type settingArguments struct {
 }
 
 func newSettingLambdaFromFile() (*settingLambda, error) {
+	// TODO tracing mode disabled if cannot open/parse/get all settings
 	settingFile, err := os.Open("/tmp/solarwinds-apm-settings.json")
 	if err != nil {
 		return nil, err

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -52,7 +52,7 @@ type settingLambdaNormalized struct {
 	args  map[string][]byte
 }
 
-// newSettingLambdaNormalized uses settings in json-unmarshalled format
+// newSettingLambdaNormalized accepts settings in json-unmarshalled format
 // for mapping to a format readable by oboe UpdateSetting.
 func newSettingLambdaNormalized(fromFile *settingLambdaFromFile) *settingLambdaNormalized {
 	flags := []byte(fromFile.Flags)
@@ -83,7 +83,8 @@ func newSettingLambdaNormalized(fromFile *settingLambdaFromFile) *settingLambdaN
 }
 
 // newSettingLambdaFromFile unmarshals sampling settings from a JSON file at a
-// specific path in a specific format, else returns error.
+// specific path in a specific format then returns values normalized for
+// oboe UpdateSetting, else returns error.
 func newSettingLambdaFromFile() (*settingLambdaNormalized, error) {
 	settingFile, err := os.Open("/tmp/solarwinds-apm-settings.json")
 	if err != nil {

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -43,7 +43,6 @@ type settingArguments struct {
 }
 
 func newSettingLambdaFromFile() (*settingLambda, error) {
-	// TODO tracing mode disabled if cannot open/parse/get all settings
 	settingFile, err := os.Open("/tmp/solarwinds-apm-settings.json")
 	if err != nil {
 		return nil, err

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -27,10 +27,10 @@ type settingLambdaFromFile struct {
 	Arguments *settingArguments `json:"arguments"`
 	Flags     string            `json:"flags"`
 	Layer     string            `json:"layer"`
-	Timestamp int               `json:"timestamp"`
+	Timestamp int64             `json:"timestamp"`
 	Ttl       int64             `json:"ttl"`
 	Stype     int               `json:"type"`
-	Value     int               `json:"value"`
+	Value     int64             `json:"value"`
 }
 
 type settingArguments struct {

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -103,8 +103,7 @@ func newSettingLambdaFromFile() (*settingLambdaNormalized, error) {
 		return nil, errors.New("settings file is incorrectly formatted")
 	}
 
-	var settingLambda settingLambdaFromFile = settingLambdas[0]
+	settingLambda := settingLambdas[0]
 
-	var settingLambdaNormalized = newSettingLambdaNormalized(&settingLambda)
-	return settingLambdaNormalized, nil
+	return newSettingLambdaNormalized(&settingLambda), nil
 }

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -52,6 +52,8 @@ type settingLambdaNormalized struct {
 	args  map[string][]byte
 }
 
+// newSettingLambdaNormalized uses settings in json-unmarshalled format
+// for mapping to a format readable by oboe UpdateSetting.
 func newSettingLambdaNormalized(fromFile *settingLambdaFromFile) *settingLambdaNormalized {
 	flags := []byte(fromFile.Flags)
 
@@ -80,6 +82,8 @@ func newSettingLambdaNormalized(fromFile *settingLambdaFromFile) *settingLambdaN
 	return &settingNorm
 }
 
+// newSettingLambdaFromFile unmarshals sampling settings from a JSON file at a
+// specific path in a specific format, else returns error.
 func newSettingLambdaFromFile() (*settingLambdaNormalized, error) {
 	settingFile, err := os.Open("/tmp/solarwinds-apm-settings.json")
 	if err != nil {

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -70,7 +70,7 @@ func newSettingLambdaNormalized(fromFile *settingLambdaFromFile) *settingLambdaN
 		[]byte(unusedToken),
 	)
 
-	settingNorm := settingLambdaNormalized{
+	settingNorm := &settingLambdaNormalized{
 		1,  // always DEFAULT_SAMPLE_RATE
 		"", // not set since type is always DEFAULT_SAMPLE_RATE
 		flags,
@@ -79,7 +79,7 @@ func newSettingLambdaNormalized(fromFile *settingLambdaFromFile) *settingLambdaN
 		args,
 	}
 
-	return &settingNorm
+	return settingNorm
 }
 
 // newSettingLambdaFromFile unmarshals sampling settings from a JSON file at a

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	stdlog "log"
 	"os"
 
 	"github.com/solarwinds/apm-go/internal/utils"
@@ -100,12 +99,7 @@ func newSettingLambdaFromFile() (*settingLambdaNormalized, error) {
 	}
 
 	var settingLambda settingLambdaFromFile = settingLambdas[0]
-	// tmp: debug
-	stdlog.Printf("settingLambda: %v", settingLambda)
-	stdlog.Printf("settingLambda.Arguments: %v", settingLambda.Arguments)
 
 	var settingLambdaNormalized = newSettingLambdaNormalized(&settingLambda)
-	// tmp: debug
-	stdlog.Printf("settingLambdaNormalized: %v", settingLambdaNormalized)
 	return settingLambdaNormalized, nil
 }

--- a/internal/oboe/settings_lambda.go
+++ b/internal/oboe/settings_lambda.go
@@ -1,0 +1,35 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oboe
+
+type settingLambda struct {
+	Arguments *settingArguments `json:"arguments"`
+	Flags     string            `json:"flags"`
+	Layer     string            `json:"layer"`
+	Timestamp int               `json:"timestamp"`
+	Ttl       int64             `json:"ttl"`
+	Stype     int               `json:"type"`
+	Value     int               `json:"value"`
+}
+
+type settingArguments struct {
+	BucketCapacity               float64 `json:"BucketCapacity"`
+	BucketRate                   float64 `json:"BucketRate"`
+	MetricsFlushInterval         int64   `json:"MetricsFlushInterval"`
+	TriggerRelaxedBucketCapacity float64 `json:"TriggerRelaxedBucketCapacity"`
+	TriggerRelaxedBucketRate     float64 `json:"TriggerRelaxedBucketRate"`
+	TriggerStrictBucketCapacity  float64 `json:"TriggerStrictBucketCapacity"`
+	TriggerStrictBucketRate      float64 `json:"TriggerStrictBucketRate"`
+}

--- a/internal/oboe/settings_lambda_test.go
+++ b/internal/oboe/settings_lambda_test.go
@@ -1,0 +1,99 @@
+// © 2024 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oboe
+
+import (
+	"testing"
+
+	"github.com/solarwinds/apm-go/internal/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSettingLambdaNormalized(t *testing.T) {
+	settingArgs := settingArguments{
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+	}
+	fromFile := settingLambdaFromFile{
+		&settingArgs,
+		"SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+		"",
+		1715900164,
+		120,
+		0,
+		1000000,
+	}
+	result := newSettingLambdaNormalized(&fromFile)
+
+	assert.Equal(t, int32(1), result.sType)
+	assert.Equal(t, "", result.layer)
+	assert.Equal(
+		t,
+		[]byte{0x53, 0x41, 0x4d, 0x50, 0x4c, 0x45, 0x5f, 0x53, 0x54, 0x41, 0x52, 0x54, 0x2c, 0x53, 0x41, 0x4d, 0x50, 0x4c, 0x45, 0x5f, 0x54, 0x48, 0x52, 0x4f, 0x55, 0x47, 0x48, 0x5f, 0x41, 0x4c, 0x57, 0x41, 0x59, 0x53, 0x2c, 0x53, 0x41, 0x4d, 0x50, 0x4c, 0x45, 0x5f, 0x42, 0x55, 0x43, 0x4b, 0x45, 0x54, 0x5f, 0x45, 0x4e, 0x41, 0x42, 0x4c, 0x45, 0x44, 0x2c, 0x54, 0x52, 0x49, 0x47, 0x47, 0x45, 0x52, 0x5f, 0x54, 0x52, 0x41, 0x43, 0x45},
+		result.flags,
+	)
+	assert.Equal(t, result.value, int64(1000000))
+	assert.Equal(t, result.ttl, int64(120))
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceRelaxedBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceRelaxedBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceStrictBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceStrictBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x1, 0x0, 0x0, 0x0},
+		result.args[constants.KvMetricsFlushInterval],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result.args[constants.KvMaxTransactions],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x54, 0x4f, 0x4b, 0x45, 0x4e},
+		result.args[constants.KvSignatureKey],
+	)
+}

--- a/internal/oboe/settings_lambda_test.go
+++ b/internal/oboe/settings_lambda_test.go
@@ -15,11 +15,15 @@
 package oboe
 
 import (
+	"os"
 	"testing"
 
 	"github.com/solarwinds/apm-go/internal/constants"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const SettingsFile = "/tmp/solarwinds-apm-settings.json"
 
 func TestNewSettingLambdaNormalized(t *testing.T) {
 	settingArgs := settingArguments{
@@ -96,4 +100,100 @@ func TestNewSettingLambdaNormalized(t *testing.T) {
 		[]byte{0x54, 0x4f, 0x4b, 0x45, 0x4e},
 		result.args[constants.KvSignatureKey],
 	)
+}
+
+func TestNewSettingLambdaFromFileErrorOpen(t *testing.T) {
+	require.NoFileExists(t, SettingsFile)
+	res, err := newSettingLambdaFromFile()
+	assert.Nil(t, res)
+	assert.Error(t, err)
+}
+
+func TestNewSettingLambdaFromFileErrorUnmarshal(t *testing.T) {
+	require.NoFileExists(t, SettingsFile)
+
+	content := []byte("hello\ngo\n")
+	os.WriteFile(SettingsFile, content, 0644)
+	res, err := newSettingLambdaFromFile()
+	assert.Nil(t, res)
+	assert.Error(t, err)
+
+	os.Remove(SettingsFile)
+}
+
+func TestNewSettingLambdaFromFileErrorLen(t *testing.T) {
+	require.NoFileExists(t, SettingsFile)
+
+	content := []byte("[]")
+	os.WriteFile(SettingsFile, content, 0644)
+	res, err := newSettingLambdaFromFile()
+	assert.Nil(t, res)
+	assert.Error(t, err)
+
+	os.Remove(SettingsFile)
+}
+
+func TestNewSettingLambdaFromFile(t *testing.T) {
+	require.NoFileExists(t, SettingsFile)
+
+	content := []byte("[{\"arguments\":{\"BucketCapacity\":1,\"BucketRate\":1,\"MetricsFlushInterval\":1,\"TriggerRelaxedBucketCapacity\":1,\"TriggerRelaxedBucketRate\":1,\"TriggerStrictBucketCapacity\":1,\"TriggerStrictBucketRate\":1},\"flags\":\"SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE\",\"layer\":\"\",\"timestamp\":1715900164,\"ttl\":120,\"type\":0,\"value\":1000000}]")
+	os.WriteFile(SettingsFile, content, 0644)
+	result, err := newSettingLambdaFromFile()
+	assert.Nil(t, err)
+	assert.Equal(t, int32(1), result.sType)
+	assert.Equal(t, "", result.layer)
+	assert.Equal(
+		t,
+		[]byte{0x53, 0x41, 0x4d, 0x50, 0x4c, 0x45, 0x5f, 0x53, 0x54, 0x41, 0x52, 0x54, 0x2c, 0x53, 0x41, 0x4d, 0x50, 0x4c, 0x45, 0x5f, 0x54, 0x48, 0x52, 0x4f, 0x55, 0x47, 0x48, 0x5f, 0x41, 0x4c, 0x57, 0x41, 0x59, 0x53, 0x2c, 0x53, 0x41, 0x4d, 0x50, 0x4c, 0x45, 0x5f, 0x42, 0x55, 0x43, 0x4b, 0x45, 0x54, 0x5f, 0x45, 0x4e, 0x41, 0x42, 0x4c, 0x45, 0x44, 0x2c, 0x54, 0x52, 0x49, 0x47, 0x47, 0x45, 0x52, 0x5f, 0x54, 0x52, 0x41, 0x43, 0x45},
+		result.flags,
+	)
+	assert.Equal(t, result.value, int64(1000000))
+	assert.Equal(t, result.ttl, int64(120))
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceRelaxedBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceRelaxedBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceStrictBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result.args[constants.KvTriggerTraceStrictBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x1, 0x0, 0x0, 0x0},
+		result.args[constants.KvMetricsFlushInterval],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result.args[constants.KvMaxTransactions],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x54, 0x4f, 0x4b, 0x45, 0x4e},
+		result.args[constants.KvSignatureKey],
+	)
+
+	os.Remove(SettingsFile)
 }

--- a/internal/oboe/settings_lambda_test.go
+++ b/internal/oboe/settings_lambda_test.go
@@ -113,7 +113,7 @@ func TestNewSettingLambdaFromFileErrorUnmarshal(t *testing.T) {
 	require.NoFileExists(t, SettingsFile)
 
 	content := []byte("hello\ngo\n")
-	os.WriteFile(SettingsFile, content, 0644)
+	require.NoError(t, os.WriteFile(SettingsFile, content, 0644))
 	res, err := newSettingLambdaFromFile()
 	assert.Nil(t, res)
 	assert.Error(t, err)
@@ -125,7 +125,7 @@ func TestNewSettingLambdaFromFileErrorLen(t *testing.T) {
 	require.NoFileExists(t, SettingsFile)
 
 	content := []byte("[]")
-	os.WriteFile(SettingsFile, content, 0644)
+	require.NoError(t, os.WriteFile(SettingsFile, content, 0644))
 	res, err := newSettingLambdaFromFile()
 	assert.Nil(t, res)
 	assert.Error(t, err)
@@ -137,7 +137,7 @@ func TestNewSettingLambdaFromFile(t *testing.T) {
 	require.NoFileExists(t, SettingsFile)
 
 	content := []byte("[{\"arguments\":{\"BucketCapacity\":1,\"BucketRate\":1,\"MetricsFlushInterval\":1,\"TriggerRelaxedBucketCapacity\":1,\"TriggerRelaxedBucketRate\":1,\"TriggerStrictBucketCapacity\":1,\"TriggerStrictBucketRate\":1},\"flags\":\"SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE\",\"layer\":\"\",\"timestamp\":1715900164,\"ttl\":120,\"type\":0,\"value\":1000000}]")
-	os.WriteFile(SettingsFile, content, 0644)
+	require.NoError(t, os.WriteFile(SettingsFile, content, 0644))
 	result, err := newSettingLambdaFromFile()
 	assert.Nil(t, err)
 	assert.Equal(t, int32(1), result.sType)

--- a/internal/oboetestutils/oboe.go
+++ b/internal/oboetestutils/oboe.go
@@ -14,70 +14,10 @@
 
 package oboetestutils
 
-import (
-	"encoding/binary"
-	"github.com/solarwinds/apm-go/internal/constants"
-	"math"
-)
+import "github.com/solarwinds/apm-go/internal/utils"
 
 const TestToken = "TOKEN"
 const TypeDefault = 0
-
-func argsToMap(capacity, ratePerSec, tRCap, tRRate, tSCap, tSRate float64,
-	metricsFlushInterval, maxTransactions int, token []byte) map[string][]byte {
-	args := make(map[string][]byte)
-
-	if capacity > -1 {
-		bits := math.Float64bits(capacity)
-		bytes := make([]byte, 8)
-		binary.LittleEndian.PutUint64(bytes, bits)
-		args[constants.KvBucketCapacity] = bytes
-	}
-	if ratePerSec > -1 {
-		bits := math.Float64bits(ratePerSec)
-		bytes := make([]byte, 8)
-		binary.LittleEndian.PutUint64(bytes, bits)
-		args[constants.KvBucketRate] = bytes
-	}
-	if tRCap > -1 {
-		bits := math.Float64bits(tRCap)
-		bytes := make([]byte, 8)
-		binary.LittleEndian.PutUint64(bytes, bits)
-		args[constants.KvTriggerTraceRelaxedBucketCapacity] = bytes
-	}
-	if tRRate > -1 {
-		bits := math.Float64bits(tRRate)
-		bytes := make([]byte, 8)
-		binary.LittleEndian.PutUint64(bytes, bits)
-		args[constants.KvTriggerTraceRelaxedBucketRate] = bytes
-	}
-	if tSCap > -1 {
-		bits := math.Float64bits(tSCap)
-		bytes := make([]byte, 8)
-		binary.LittleEndian.PutUint64(bytes, bits)
-		args[constants.KvTriggerTraceStrictBucketCapacity] = bytes
-	}
-	if tSRate > -1 {
-		bits := math.Float64bits(tSRate)
-		bytes := make([]byte, 8)
-		binary.LittleEndian.PutUint64(bytes, bits)
-		args[constants.KvTriggerTraceStrictBucketRate] = bytes
-	}
-	if metricsFlushInterval > -1 {
-		bytes := make([]byte, 4)
-		binary.LittleEndian.PutUint32(bytes, uint32(metricsFlushInterval))
-		args[constants.KvMetricsFlushInterval] = bytes
-	}
-	if maxTransactions > -1 {
-		bytes := make([]byte, 4)
-		binary.LittleEndian.PutUint32(bytes, uint32(maxTransactions))
-		args[constants.KvMaxTransactions] = bytes
-	}
-
-	args[constants.KvSignatureKey] = token
-
-	return args
-}
 
 type SettingUpdater interface {
 	UpdateSetting(sType int32, layer string, flags []byte, value int64, ttl int64, args map[string][]byte)
@@ -87,48 +27,48 @@ func AddDefaultSetting(o SettingUpdater) {
 	// add default setting with 100% sampling
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,TRIGGER_TRACE"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
+		1000000, 120, utils.ArgsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func AddSampleThrough(o SettingUpdater) {
 	// add default setting with 100% sampling
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH,TRIGGER_TRACE"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
+		1000000, 120, utils.ArgsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func AddNoTriggerTrace(o SettingUpdater) {
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 0, 0, 0, 0, -1, -1, []byte(TestToken)))
+		1000000, 120, utils.ArgsToMap(1000000, 1000000, 0, 0, 0, 0, -1, -1, []byte(TestToken)))
 }
 
 func AddTriggerTraceOnly(o SettingUpdater) {
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte("TRIGGER_TRACE"),
-		0, 120, argsToMap(0, 0, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
+		0, 120, utils.ArgsToMap(0, 0, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func AddRelaxedTriggerTraceOnly(o SettingUpdater) {
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte("TRIGGER_TRACE"),
-		0, 120, argsToMap(0, 0, 1000000, 1000000, 0, 0, -1, -1, []byte(TestToken)))
+		0, 120, utils.ArgsToMap(0, 0, 1000000, 1000000, 0, 0, -1, -1, []byte(TestToken)))
 }
 
 func AddStrictTriggerTraceOnly(o SettingUpdater) {
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte("TRIGGER_TRACE"),
-		0, 120, argsToMap(0, 0, 0, 0, 1000000, 1000000, -1, -1, []byte(TestToken)))
+		0, 120, utils.ArgsToMap(0, 0, 0, 0, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func AddLimitedTriggerTrace(o SettingUpdater) {
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,TRIGGER_TRACE"),
-		1000000, 120, argsToMap(1000000, 1000000, 1, 1, 1, 1, -1, -1, []byte(TestToken)))
+		1000000, 120, utils.ArgsToMap(1000000, 1000000, 1, 1, 1, 1, -1, -1, []byte(TestToken)))
 }
 
 func AddDisabled(o SettingUpdater) {
 	o.UpdateSetting(int32(TypeDefault), "",
 		[]byte(""),
-		0, 120, argsToMap(0, 0, 1, 1, 1, 1, -1, -1, []byte(TestToken)))
+		0, 120, utils.ArgsToMap(0, 0, 1, 1, 1, 1, -1, -1, []byte(TestToken)))
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -136,6 +136,8 @@ func IsHigherOrEqualGoVersion(version string) bool {
 	return true
 }
 
+// ArgsToMap uses settings as float/int/bytes to create a map of string keys
+// to bytes, for usability by oboe UpdateSetting.
 func ArgsToMap(capacity, ratePerSec, tRCap, tRRate, tSCap, tSRate float64,
 	metricsFlushInterval, maxTransactions int, token []byte) map[string][]byte {
 	args := make(map[string][]byte)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -17,12 +17,15 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
+	"math"
 	"os"
 	"runtime"
 	"strings"
 	"sync"
 
+	"github.com/solarwinds/apm-go/internal/constants"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -131,6 +134,62 @@ func IsHigherOrEqualGoVersion(version string) bool {
 		}
 	}
 	return true
+}
+
+func ArgsToMap(capacity, ratePerSec, tRCap, tRRate, tSCap, tSRate float64,
+	metricsFlushInterval, maxTransactions int, token []byte) map[string][]byte {
+	args := make(map[string][]byte)
+
+	if capacity > -1 {
+		bits := math.Float64bits(capacity)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[constants.KvBucketCapacity] = bytes
+	}
+	if ratePerSec > -1 {
+		bits := math.Float64bits(ratePerSec)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[constants.KvBucketRate] = bytes
+	}
+	if tRCap > -1 {
+		bits := math.Float64bits(tRCap)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[constants.KvTriggerTraceRelaxedBucketCapacity] = bytes
+	}
+	if tRRate > -1 {
+		bits := math.Float64bits(tRRate)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[constants.KvTriggerTraceRelaxedBucketRate] = bytes
+	}
+	if tSCap > -1 {
+		bits := math.Float64bits(tSCap)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[constants.KvTriggerTraceStrictBucketCapacity] = bytes
+	}
+	if tSRate > -1 {
+		bits := math.Float64bits(tSRate)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[constants.KvTriggerTraceStrictBucketRate] = bytes
+	}
+	if metricsFlushInterval > -1 {
+		bytes := make([]byte, 4)
+		binary.LittleEndian.PutUint32(bytes, uint32(metricsFlushInterval))
+		args[constants.KvMetricsFlushInterval] = bytes
+	}
+	if maxTransactions > -1 {
+		bytes := make([]byte, 4)
+		binary.LittleEndian.PutUint32(bytes, uint32(maxTransactions))
+		args[constants.KvMaxTransactions] = bytes
+	}
+
+	args[constants.KvSignatureKey] = token
+
+	return args
 }
 
 // SafeBuffer is goroutine-safe buffer. It is for internal test use only.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,124 @@
+// © 2024 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/solarwinds/apm-go/internal/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+const TestToken = "TOKEN"
+
+func TestArgsToMapAllSet(t *testing.T) {
+	result := ArgsToMap(1, 1, 1, 1, 1, 1, 1, 1, []byte(TestToken))
+
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result[constants.KvBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result[constants.KvBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result[constants.KvTriggerTraceRelaxedBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result[constants.KvTriggerTraceRelaxedBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result[constants.KvTriggerTraceStrictBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		result[constants.KvTriggerTraceStrictBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x1, 0x0, 0x0, 0x0},
+		result[constants.KvMetricsFlushInterval],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x1, 0x0, 0x0, 0x0},
+		result[constants.KvMaxTransactions],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x54, 0x4f, 0x4b, 0x45, 0x4e},
+		result[constants.KvSignatureKey],
+	)
+}
+
+func TestArgsToMapAllUnset(t *testing.T) {
+	result := ArgsToMap(-1, -1, -1, -1, -1, -1, -1, -1, []byte(TestToken))
+
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvTriggerTraceRelaxedBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvTriggerTraceRelaxedBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvTriggerTraceStrictBucketCapacity],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvTriggerTraceStrictBucketRate],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvMetricsFlushInterval],
+	)
+	assert.Equal(
+		t,
+		[]byte(nil),
+		result[constants.KvMaxTransactions],
+	)
+	assert.Equal(
+		t,
+		[]byte{0x54, 0x4f, 0x4b, 0x45, 0x4e},
+		result[constants.KvSignatureKey],
+	)
+}

--- a/swo/agent.go
+++ b/swo/agent.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	stdlog "log"
 	"strings"
-	"time"
 
 	"github.com/solarwinds/apm-go/internal/config"
 	"github.com/solarwinds/apm-go/internal/entryspans"
@@ -95,10 +94,7 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 	o := oboe.NewOboe()
 
 	// TODO only if in lambda
-	settingsTicker := time.NewTicker(30 * time.Second)
-	for range settingsTicker.C {
-		o.UpdateSettingFromFile()
-	}
+	go o.StartSettingTicker()
 
 	_reporter, err := reporter.Start(resrc, registry, o)
 	if err != nil {
@@ -128,7 +124,7 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 	return func() {
 		// stop ticker
 		// TODO only if in lambda
-		settingsTicker.Stop()
+		o.StopSettingTicker()
 
 		// shut down TracerProvider, and log error if issues
 		if err := tp.Shutdown(context.Background()); err != nil {

--- a/swo/agent.go
+++ b/swo/agent.go
@@ -94,7 +94,8 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 	o := oboe.NewOboe()
 
 	// TODO only if in lambda
-	go o.StartSettingTicker()
+	fbw := oboe.NewFileBasedWatcher(&o)
+	go fbw.Start()
 
 	_reporter, err := reporter.Start(resrc, registry, o)
 	if err != nil {
@@ -124,7 +125,7 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 	return func() {
 		// stop ticker
 		// TODO only if in lambda
-		o.StopSettingTicker()
+		fbw.Stop()
 
 		// shut down TracerProvider, and log error if issues
 		if err := tp.Shutdown(context.Background()); err != nil {

--- a/swo/agent.go
+++ b/swo/agent.go
@@ -94,7 +94,15 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 	o := oboe.NewOboe()
 
 	// TODO only if in lambda
-	go o.StartSettingTicker()
+	// Attempt to get lambda settings first time; disable tracing if error
+	ok := o.UpdateSettingFromFile()
+	if !ok {
+		// TODO tracing mode disabled if cannot open/parse/get all settings
+		stdlog.Print("TODO: could not update setting from file; tracing disabled")
+	} else {
+		// start regular settings file reading
+		go o.StartSettingTicker()
+	}
 
 	_reporter, err := reporter.Start(resrc, registry, o)
 	if err != nil {

--- a/swo/agent.go
+++ b/swo/agent.go
@@ -94,15 +94,7 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 	o := oboe.NewOboe()
 
 	// TODO only if in lambda
-	// Attempt to get lambda settings first time; disable tracing if error
-	ok := o.UpdateSettingFromFile()
-	if !ok {
-		// TODO tracing mode disabled if cannot open/parse/get all settings
-		stdlog.Print("TODO: could not update setting from file; tracing disabled")
-	} else {
-		// start regular settings file reading
-		go o.StartSettingTicker()
-	}
+	go o.StartSettingTicker()
 
 	_reporter, err := reporter.Start(resrc, registry, o)
 	if err != nil {


### PR DESCRIPTION
Changes:
1. Adds `settings_lambda.go` to unmarshal values from settings.json file and normalize them to what's usable by existing `oboe.UpdateSetting` (a mix of int, string, []byte, and map of []byte).
2. Move `ArgsToMap` from test util to regular util, used by settings_lambda.
3. Adds `oboe.FileBasedWatcher` that can do `Start`/`Stop` of a ticker that ticks every 10 seconds.
4. At every tick, `FileBasedWatcher` uses settings_lambda to print normalized settings.

Example settings.json contents:
`[{"arguments":{"BucketCapacity":6.800000000000001,"BucketRate":0.37400000000000005,"MetricsFlushInterval":60,"TriggerRelaxedBucketCapacity":20,"TriggerRelaxedBucketRate":1,"TriggerStrictBucketCapacity":6,"TriggerStrictBucketRate":0.1},"flags":"SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE","layer":"","timestamp":1715900164,"ttl":120,"type":0,"value":1000000}]`

Example printout:
`2024/05/24 19:04:49 Got lambda settings from file:`
`&{1  [83 65 77 80 76 69 95 83 84 65 82 84 44 83 65 77 80 76 69 95 84 72 82 79 85 71 72 95 65 76 87 65 89 83 44 83 65 77 80 76 69 95 66 85 67 75 69 84 95 69 78 65 66 76 69 68 44 84 82 73 71 71 69 82 95 84 82 65 67 69] 1000000 120 map[BucketCapacity:[52 51 51 51 51 51 27 64] BucketRate:[87 14 45 178 157 239 215 63] MetricsFlushInterval:[60 0 0 0] SignatureKey:[84 79 75 69 78] TriggerRelaxedBucketCapacity:[0 0 0 0 0 0 52 64] TriggerRelaxedBucketRate:[0 0 0 0 0 0 240 63] TriggerStrictBucketCapacity:[0 0 0 0 0 0 24 64] TriggerStrictBucketRate:[154 153 153 153 153 153 185 63]]}`

----

For future PRs:
* Actually add the init and Start/Stop of `FileBasedWatcher` when in lambda, because right now it won't run. At its crudest it could look like what was removed from agent.go in [8efdc1b](https://github.com/solarwinds/apm-go/pull/91/commits/8efdc1bb7dbafd22dd19d1a4d2127164d909f996), but incorporating an upcoming lambda wrapper would be better.
* Add disabling of APM Go if settings.json can't be found/opened/read or bad values.
* Get _someone_ (maybe `FileBasedWatcher` or sampling logic) to actually set internal goboe settings using file contents so that it's not too far off how sampling and settings are used outside lambda. This may involve caching of settings like liboboe.
* ??? 