### PR TITLE
NH-81286 Remove TypeLayer and SampleSourceLayer

### DIFF
--- a/internal/oboe/oboe.go
+++ b/internal/oboe/oboe.go
@@ -43,7 +43,6 @@ const (
 	SampleSourceNone
 	SampleSourceFile
 	SampleSourceDefault
-	SampleSourceLayer
 )
 
 type Oboe interface {
@@ -272,7 +271,7 @@ func (o *oboe) GetSetting() (*settings, bool) {
 	o.RLock()
 	defer o.RUnlock()
 
-	// for now only look up the default settings
+	// always use the default setting
 	key := settingKey{
 		sType: TypeDefault,
 		layer: "",
@@ -288,6 +287,7 @@ func (o *oboe) RemoveSetting() {
 	o.Lock()
 	defer o.Unlock()
 
+	// always use the default setting
 	key := settingKey{
 		sType: TypeDefault,
 		layer: "",

--- a/internal/oboe/settings.go
+++ b/internal/oboe/settings.go
@@ -15,9 +15,10 @@
 package oboe
 
 import (
+	"time"
+
 	"github.com/solarwinds/apm-go/internal/config"
 	"github.com/solarwinds/apm-go/internal/log"
-	"time"
 )
 
 type settings struct {
@@ -132,8 +133,7 @@ type settingFlag uint16
 
 // setting types
 const (
-	TypeDefault settingType = iota // default setting which serves as a fallback if no other settings found
-	TypeLayer                      // layer specific settings
+	TypeDefault settingType = iota // default setting and the only accepted setting
 )
 
 // setting flags offset
@@ -174,8 +174,6 @@ func (st settingType) toSampleSource() SampleSource {
 	switch st {
 	case TypeDefault:
 		source = SampleSourceDefault
-	case TypeLayer:
-		source = SampleSourceLayer
 	default:
 		source = SampleSourceNone
 	}


### PR DESCRIPTION
Removes `TypeLayer` and `SampleSourceLayer` because APM Go does not support layer-based setting.

Keeping `SampleSourceFile` because used by `mergeLocalSetting`.