### PR TITLE
NH-78295 Split grpcReporter `getSetting`

### DIFF
--- a/internal/reporter/reporter_grpc.go
+++ b/internal/reporter/reporter_grpc.go
@@ -90,7 +90,7 @@ ftgwcxyEq5SkiR+6BCwdzAMqADV37TzXDHLjwSrMIrgLV5xZM20Kk6chxI5QAr/f
 	// These are hard-coded parameters for the gRPC reporter. Any of them become
 	// configurable in future versions will be moved to package config.
 	// TODO: use time.Time
-	grpcGetSettingsIntervalDefault          = 30               // default settings retrieval interval in seconds
+	grpcGetAndUpdateSettingsIntervalDefault = 30               // default settings retrieval interval in seconds
 	grpcSettingsTimeoutCheckIntervalDefault = 10               // default check interval for timed out settings in seconds
 	grpcPingIntervalDefault                 = 20               // default interval for keep alive pings in seconds
 	grpcRetryDelayInitial                   = 500              // initial connection/send retry delay in milliseconds
@@ -303,7 +303,7 @@ func newGRPCReporter(otelServiceName string, registry metrics.LegacyRegistry, o 
 		conn: grpcConn,
 
 		collectMetricInterval:        metrics.ReportingIntervalDefault,
-		getAndUpdateSettingsInterval: grpcGetSettingsIntervalDefault,
+		getAndUpdateSettingsInterval: grpcGetAndUpdateSettingsIntervalDefault,
 		settingsTimeoutCheckInterval: grpcSettingsTimeoutCheckIntervalDefault,
 
 		serviceKey:      uatomic.NewString(config.GetServiceKey()),

--- a/internal/reporter/reporter_grpc.go
+++ b/internal/reporter/reporter_grpc.go
@@ -864,16 +864,16 @@ func (r *grpcReporter) getAndUpdateSettings(ready chan bool) {
 	if err == nil {
 		r.updateSettings(remoteSettings)
 	} else {
-		log.Error("Could not getAndUpdateSettings: %s", err)
+		log.Errorf("Could not getAndUpdateSettings: %s", err)
 	}
 }
 
 // retrieves settings from collector and returns them
 func (r *grpcReporter) getSettings() (*collector.SettingsResult, error) {
 	method := newGetSettingsMethod(r.serviceKey.Load())
-	err := r.conn.InvokeRPC(r.done, method)
 
-	if err == nil {
+	var err error
+	if err := r.conn.InvokeRPC(r.done, method); err == nil {
 		logger := log.Info
 		if method.Resp.Warning != "" {
 			logger = log.Warning

--- a/internal/reporter/reporter_grpc.go
+++ b/internal/reporter/reporter_grpc.go
@@ -22,6 +22,18 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/solarwinds/apm-go/internal/config"
 	"github.com/solarwinds/apm-go/internal/constants"
@@ -34,17 +46,6 @@ import (
 	"github.com/solarwinds/apm-go/internal/oboe"
 	"github.com/solarwinds/apm-go/internal/uams"
 	"github.com/solarwinds/apm-go/internal/utils"
-	"io"
-	"math"
-	"net"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"os"
-	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
 
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
@@ -619,7 +620,7 @@ func (r *grpcReporter) periodicTasks() {
 			select {
 			case <-getSettingsReady:
 				// only kick off a new goroutine if the previous one has terminated
-				go r.getSettings(getSettingsReady)
+				go r.getAndUpdateSettings(getSettingsReady)
 			default:
 			}
 		case <-settingsTimeoutCheckTicker.C: // check for timed out settings
@@ -853,25 +854,38 @@ func (r *grpcReporter) sendMetrics(msgs [][]byte) {
 
 // ================================ Settings Handling ====================================
 
-// retrieves the settings from the collector
+// retrieves the settings from the collector and updates APM with them
 // ready	a 'ready' channel to indicate if this routine has terminated
-func (r *grpcReporter) getSettings(ready chan bool) {
+func (r *grpcReporter) getAndUpdateSettings(ready chan bool) {
 	// notify caller that this routine has terminated (defered to end of routine)
 	defer func() { ready <- true }()
 
+	remoteSettings, err := r.getSettings()
+	if err == nil {
+		r.updateSettings(remoteSettings)
+	} else {
+		log.Error("Could not getAndUpdateSettings: %s", err)
+	}
+}
+
+// retrieves settings from collector and returns them
+func (r *grpcReporter) getSettings() (*collector.SettingsResult, error) {
 	method := newGetSettingsMethod(r.serviceKey.Load())
-	if err := r.conn.InvokeRPC(r.done, method); err == nil {
+	err := r.conn.InvokeRPC(r.done, method)
+
+	if err == nil {
 		logger := log.Info
 		if method.Resp.Warning != "" {
 			logger = log.Warning
 		}
 		logger(method.CallSummary())
-		r.updateSettings(method.Resp)
+		return method.Resp, nil
 	} else if errors.Is(err, errInvalidServiceKey) {
 		r.ShutdownNow()
 	} else {
 		log.Infof("getSettings: %s", err)
 	}
+	return nil, err
 }
 
 // updates the existing settings with the newly received

--- a/internal/reporter/reporter_grpc.go
+++ b/internal/reporter/reporter_grpc.go
@@ -872,7 +872,6 @@ func (r *grpcReporter) getAndUpdateSettings(ready chan bool) {
 func (r *grpcReporter) getSettings() (*collector.SettingsResult, error) {
 	method := newGetSettingsMethod(r.serviceKey.Load())
 
-	var err error
 	if err := r.conn.InvokeRPC(r.done, method); err == nil {
 		logger := log.Info
 		if method.Resp.Warning != "" {
@@ -882,10 +881,11 @@ func (r *grpcReporter) getSettings() (*collector.SettingsResult, error) {
 		return method.Resp, nil
 	} else if errors.Is(err, errInvalidServiceKey) {
 		r.ShutdownNow()
+		return nil, err
 	} else {
 		log.Infof("getSettings: %s", err)
+		return nil, err
 	}
-	return nil, err
 }
 
 // updates the existing settings with the newly received

--- a/internal/reporter/reporter_grpc.go
+++ b/internal/reporter/reporter_grpc.go
@@ -863,6 +863,8 @@ func (r *grpcReporter) getAndUpdateSettings(ready chan bool) {
 	remoteSettings, err := r.getSettings()
 	if err == nil {
 		r.updateSettings(remoteSettings)
+	} else if errors.Is(err, errInvalidServiceKey) {
+		r.ShutdownNow()
 	} else {
 		log.Errorf("Could not getAndUpdateSettings: %s", err)
 	}
@@ -871,7 +873,6 @@ func (r *grpcReporter) getAndUpdateSettings(ready chan bool) {
 // retrieves settings from collector and returns them
 func (r *grpcReporter) getSettings() (*collector.SettingsResult, error) {
 	method := newGetSettingsMethod(r.serviceKey.Load())
-
 	if err := r.conn.InvokeRPC(r.done, method); err == nil {
 		logger := log.Info
 		if method.Resp.Warning != "" {
@@ -879,9 +880,6 @@ func (r *grpcReporter) getSettings() (*collector.SettingsResult, error) {
 		}
 		logger(method.CallSummary())
 		return method.Resp, nil
-	} else if errors.Is(err, errInvalidServiceKey) {
-		r.ShutdownNow()
-		return nil, err
 	} else {
 		log.Infof("getSettings: %s", err)
 		return nil, err

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -16,6 +16,12 @@ package reporter
 
 import (
 	"context"
+	"io"
+	stdlog "log"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/solarwinds/apm-go/internal/config"
 	"github.com/solarwinds/apm-go/internal/constants"
 	"github.com/solarwinds/apm-go/internal/host"
@@ -29,11 +35,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
-	"io"
-	stdlog "log"
-	"os"
-	"testing"
-	"time"
 
 	"strings"
 
@@ -100,7 +101,7 @@ func TestGRPCReporter(t *testing.T) {
 
 	// The reporter becomes ready after it has got the default setting.
 	ready := make(chan bool, 1)
-	r.getSettings(ready)
+	r.getAndUpdateSettings(ready)
 	ctxTm2, cancel2 := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel2()
 	require.True(t, r.WaitForReady(ctxTm2))
@@ -124,7 +125,7 @@ func TestGRPCReporter(t *testing.T) {
 	require.Equal(t, TestServiceKey, r.serviceKey.Load())
 
 	require.Equal(t, int32(metrics.ReportingIntervalDefault), r.collectMetricInterval)
-	require.Equal(t, grpcGetSettingsIntervalDefault, r.getSettingsInterval)
+	require.Equal(t, grpcGetSettingsIntervalDefault, r.getAndUpdateSettingsInterval)
 	require.Equal(t, grpcSettingsTimeoutCheckIntervalDefault, r.settingsTimeoutCheckInterval)
 
 	time.Sleep(time.Second)
@@ -505,7 +506,7 @@ func testProxy(t *testing.T, proxyUrl string) {
 
 	// The reporter becomes ready after it has got the default setting.
 	ready := make(chan bool, 1)
-	r.getSettings(ready)
+	r.getAndUpdateSettings(ready)
 	ctxTm2, cancel2 := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel2()
 	require.True(t, r.WaitForReady(ctxTm2))
@@ -532,7 +533,7 @@ func testProxy(t *testing.T, proxyUrl string) {
 	require.Equal(t, TestServiceKey, r.serviceKey.Load())
 
 	require.Equal(t, int32(metrics.ReportingIntervalDefault), r.collectMetricInterval)
-	require.Equal(t, grpcGetSettingsIntervalDefault, r.getSettingsInterval)
+	require.Equal(t, grpcGetSettingsIntervalDefault, r.getAndUpdateSettingsInterval)
 	require.Equal(t, grpcSettingsTimeoutCheckIntervalDefault, r.settingsTimeoutCheckInterval)
 
 	time.Sleep(time.Second)

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -125,7 +125,7 @@ func TestGRPCReporter(t *testing.T) {
 	require.Equal(t, TestServiceKey, r.serviceKey.Load())
 
 	require.Equal(t, int32(metrics.ReportingIntervalDefault), r.collectMetricInterval)
-	require.Equal(t, grpcGetSettingsIntervalDefault, r.getAndUpdateSettingsInterval)
+	require.Equal(t, grpcGetAndUpdateSettingsIntervalDefault, r.getAndUpdateSettingsInterval)
 	require.Equal(t, grpcSettingsTimeoutCheckIntervalDefault, r.settingsTimeoutCheckInterval)
 
 	time.Sleep(time.Second)
@@ -533,7 +533,7 @@ func testProxy(t *testing.T, proxyUrl string) {
 	require.Equal(t, TestServiceKey, r.serviceKey.Load())
 
 	require.Equal(t, int32(metrics.ReportingIntervalDefault), r.collectMetricInterval)
-	require.Equal(t, grpcGetSettingsIntervalDefault, r.getAndUpdateSettingsInterval)
+	require.Equal(t, grpcGetAndUpdateSettingsIntervalDefault, r.getAndUpdateSettingsInterval)
 	require.Equal(t, grpcSettingsTimeoutCheckIntervalDefault, r.settingsTimeoutCheckInterval)
 
 	time.Sleep(time.Second)


### PR DESCRIPTION
Splits grpcReporter's `getSettings` into `getAndUpdateSettings` + `getSettings` + `updateSettings`. The reporter's ticking to periodically update oboe settings still works the same way. This is a step towards reducing reporter's current settings-related responsibilities.

The rest and most of this is renaming related vars/methods for clarity.

This is pointed at `main`.