### PR TITLE
NH-102273 use valid toolchain version syntax

### DIFF
--- a/examples/grpc/go.mod
+++ b/examples/grpc/go.mod
@@ -14,7 +14,7 @@
 
 module github.com/solarwinds/apm-go/examples/grpc
 
-go 1.23
+go 1.23.0
 
 // TODO don't use the local repo
 replace github.com/solarwinds/apm-go => ../..

--- a/examples/http/go.mod
+++ b/examples/http/go.mod
@@ -14,7 +14,7 @@
 
 module github.com/solarwinds/apm-go/examples/http
 
-go 1.23
+go 1.23.0
 
 // TODO don't use the local repo
 replace github.com/solarwinds/apm-go => ../..

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@
 
 module github.com/solarwinds/apm-go
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.2

--- a/instrumentation/github.com/aws/aws-lambda-go/swolambda/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/swolambda/go.mod
@@ -14,7 +14,7 @@
 
 module github.com/solarwinds/apm-go/instrumentation/github.com/aws/aws-lambda-go/swolambda
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0


### PR DESCRIPTION
After https://github.com/solarwinds/apm-go/pull/192, CodeQL is warning about invalid toolchain version:

As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version)