### PR TITLE
NH-108953 Fix for inaccurate tracecount metric value

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,12 +16,6 @@ package metrics
 
 import (
 	"errors"
-	"github.com/solarwinds/apm-go/internal/bson"
-	"github.com/solarwinds/apm-go/internal/config"
-	"github.com/solarwinds/apm-go/internal/hdrhist"
-	"github.com/solarwinds/apm-go/internal/host"
-	"github.com/solarwinds/apm-go/internal/log"
-	"github.com/solarwinds/apm-go/internal/utils"
 	"runtime"
 	"sort"
 	"strconv"
@@ -29,6 +23,13 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/solarwinds/apm-go/internal/bson"
+	"github.com/solarwinds/apm-go/internal/config"
+	"github.com/solarwinds/apm-go/internal/hdrhist"
+	"github.com/solarwinds/apm-go/internal/host"
+	"github.com/solarwinds/apm-go/internal/log"
+	"github.com/solarwinds/apm-go/internal/utils"
 )
 
 const (
@@ -175,63 +176,9 @@ func (s *EventQueueStats) TotalEventsAdd(n int64) {
 	atomic.AddInt64(&s.totalEvents, n)
 }
 
-// RateCounts is the rate counts reported by trace sampler
-type RateCounts struct{ requested, sampled, limited, traced, through int64 }
-
 // RateCountSummary is used to merge RateCounts from multiple token buckets
 type RateCountSummary struct {
 	Requested, Traced, Limited, TtTraced, Sampled, Through int64
-}
-
-// FlushRateCounts reset the counters and returns the current value
-func (c *RateCounts) FlushRateCounts() *RateCounts {
-	return &RateCounts{
-		requested: atomic.SwapInt64(&c.requested, 0),
-		sampled:   atomic.SwapInt64(&c.sampled, 0),
-		limited:   atomic.SwapInt64(&c.limited, 0),
-		traced:    atomic.SwapInt64(&c.traced, 0),
-		through:   atomic.SwapInt64(&c.through, 0),
-	}
-}
-
-func (c *RateCounts) RequestedInc() {
-	atomic.AddInt64(&c.requested, 1)
-}
-
-func (c *RateCounts) Requested() int64 {
-	return atomic.LoadInt64(&c.requested)
-}
-
-func (c *RateCounts) SampledInc() {
-	atomic.AddInt64(&c.sampled, 1)
-}
-
-func (c *RateCounts) Sampled() int64 {
-	return atomic.LoadInt64(&c.sampled)
-}
-
-func (c *RateCounts) LimitedInc() {
-	atomic.AddInt64(&c.limited, 1)
-}
-
-func (c *RateCounts) Limited() int64 {
-	return atomic.LoadInt64(&c.limited)
-}
-
-func (c *RateCounts) TracedInc() {
-	atomic.AddInt64(&c.traced, 1)
-}
-
-func (c *RateCounts) Traced() int64 {
-	return atomic.LoadInt64(&c.traced)
-}
-
-func (c *RateCounts) ThroughInc() {
-	atomic.AddInt64(&c.through, 1)
-}
-
-func (c *RateCounts) Through() int64 {
-	return atomic.LoadInt64(&c.through)
 }
 
 // addRequestCounters add various request-related counters to the metrics message buffer.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -513,31 +513,6 @@ func TestEventQueueStats(t *testing.T) {
 	assert.Equal(t, original, *swapped)
 }
 
-func TestRateCounts(t *testing.T) {
-	rc := &RateCounts{}
-
-	rc.RequestedInc()
-	assert.EqualValues(t, 1, rc.Requested())
-
-	rc.SampledInc()
-	assert.EqualValues(t, 1, rc.Sampled())
-
-	rc.LimitedInc()
-	assert.EqualValues(t, 1, rc.Limited())
-
-	rc.TracedInc()
-	assert.EqualValues(t, 1, rc.Traced())
-
-	rc.ThroughInc()
-	assert.EqualValues(t, 1, rc.Through())
-
-	original := *rc
-	cp := rc.FlushRateCounts()
-
-	assert.Equal(t, original, *cp)
-	assert.Equal(t, &RateCounts{}, rc)
-}
-
 func TestRecordSpan(t *testing.T) {
 	tr, teardown := testutils.TracerSetup()
 	defer teardown()

--- a/internal/metrics/rate_counts.go
+++ b/internal/metrics/rate_counts.go
@@ -1,0 +1,72 @@
+package metrics
+
+import "sync/atomic"
+
+// RateCounts is the rate counts reported by trace sampler
+type RateCounts struct{ requested, sampled, limited, traced, through, ttraced int64 }
+
+var rateCountsAggregator = &RateCounts{}
+
+func RatesAggregator() *RateCounts {
+	return rateCountsAggregator
+}
+
+// FlushRateCounts reset the counters and returns the current value
+func (c *RateCounts) FlushRateCounts() *RateCounts {
+	return &RateCounts{
+		requested: atomic.SwapInt64(&c.requested, 0),
+		sampled:   atomic.SwapInt64(&c.sampled, 0),
+		limited:   atomic.SwapInt64(&c.limited, 0),
+		traced:    atomic.SwapInt64(&c.traced, 0),
+		through:   atomic.SwapInt64(&c.through, 0),
+		ttraced:   atomic.SwapInt64(&c.ttraced, 0),
+	}
+}
+
+func (c *RateCounts) RequestedInc() {
+	atomic.AddInt64(&c.requested, 1)
+}
+
+func (c *RateCounts) Requested() int64 {
+	return atomic.LoadInt64(&c.requested)
+}
+
+func (c *RateCounts) SampledInc() {
+	atomic.AddInt64(&c.sampled, 1)
+}
+
+func (c *RateCounts) Sampled() int64 {
+	return atomic.LoadInt64(&c.sampled)
+}
+
+func (c *RateCounts) LimitedInc() {
+	atomic.AddInt64(&c.limited, 1)
+}
+
+func (c *RateCounts) Limited() int64 {
+	return atomic.LoadInt64(&c.limited)
+}
+
+func (c *RateCounts) TracedInc() {
+	atomic.AddInt64(&c.traced, 1)
+}
+
+func (c *RateCounts) Traced() int64 {
+	return atomic.LoadInt64(&c.traced)
+}
+
+func (c *RateCounts) ThroughInc() {
+	atomic.AddInt64(&c.through, 1)
+}
+
+func (c *RateCounts) Through() int64 {
+	return atomic.LoadInt64(&c.through)
+}
+
+func (c *RateCounts) TriggerTraceInc() {
+	atomic.AddInt64(&c.ttraced, 1)
+}
+
+func (c *RateCounts) TriggerTrace() int64 {
+	return atomic.LoadInt64(&c.ttraced)
+}

--- a/internal/metrics/rate_counts_test.go
+++ b/internal/metrics/rate_counts_test.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateCounts(t *testing.T) {
+	rc := &RateCounts{}
+
+	rc.RequestedInc()
+	assert.EqualValues(t, 1, rc.Requested())
+
+	rc.SampledInc()
+	assert.EqualValues(t, 1, rc.Sampled())
+
+	rc.LimitedInc()
+	assert.EqualValues(t, 1, rc.Limited())
+
+	rc.TracedInc()
+	assert.EqualValues(t, 1, rc.Traced())
+
+	rc.ThroughInc()
+	assert.EqualValues(t, 1, rc.Through())
+
+	original := *rc
+	cp := rc.FlushRateCounts()
+
+	assert.Equal(t, original, *cp)
+	assert.Equal(t, &RateCounts{}, rc)
+}


### PR DESCRIPTION
### Summary
There is a discrepancy between number of traces reported as SUM of `trace.service.tracecount` metric vs effective number of traces in the system. 
Trace count metrics value is too low because it is periodically clear by settings update.