### PR TITLE
NH-123509: add test case that cover the API (external) call to avoid false positive from deadcode

### DIFF
--- a/instrumentation/net/http/swohttp/handler_test.go
+++ b/instrumentation/net/http/swohttp/handler_test.go
@@ -99,3 +99,26 @@ func doRequest(t *testing.T, xtOpts string) *http.Response {
 	handler.ServeHTTP(recorder, req)
 	return recorder.Result()
 }
+
+func TestWrapBaseHandler(t *testing.T) {
+	defer setupTest(t)()
+
+	cb, err := swo.Start()
+	require.NoError(t, err)
+	defer cb()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("wrapped"))
+		require.NoError(t, err)
+	})
+	handler := WrapBaseHandler(inner, "test-operation")
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	handler.ServeHTTP(recorder, req)
+
+	resp := recorder.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, XTrace, resp.Header.Get(ACEHdr))
+	require.Regexp(t, xtraceRegexp, resp.Header.Get(XTrace))
+}

--- a/swo/agent_lambda_test.go
+++ b/swo/agent_lambda_test.go
@@ -1,0 +1,79 @@
+// © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swo
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestStartLambdaAndFlush(t *testing.T) {
+	// Start a local TCP listener to accept gRPC connections
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lis.Close()) }()
+
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+lis.Addr().String())
+	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+	t.Setenv("SW_APM_SERVICE_KEY", "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:test")
+
+	// StartLambda return Flusher object
+	flusher, err := StartLambda("test-log-stream")
+	require.NoError(t, err)
+	require.NotNil(t, flusher)
+	// require.NoError(t, flusher.Flush(context.Background()))
+	flushCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = flusher.Flush(flushCtx) //nolint:errcheck — export fails without server, expected
+
+	// Verify resource attributes set by StartLambda.
+	// Register a SpanRecorder, then emit a span with a local sampled parent so
+	// the oboe sampler passes it through (non-remote sampled parent → always sample).
+	tp, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	require.True(t, ok, "global tracer provider should be *sdktrace.TracerProvider")
+
+	rec := tracetest.NewSpanRecorder()
+	tp.RegisterSpanProcessor(rec)
+
+	// Use a local (non-remote), sampled parent span context so the oboe sampler
+	// defers to AlwaysSample, ensuring the span is recorded.
+	parent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x01},
+		SpanID:     trace.SpanID{0x01},
+		TraceFlags: trace.FlagsSampled,
+		Remote:     false,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), parent)
+	_, span := otel.Tracer("test").Start(ctx, "probe")
+	span.End()
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+
+	attrs := make(map[string]string)
+	for _, kv := range ended[0].Resource().Attributes() {
+		attrs[string(kv.Key)] = kv.Value.AsString()
+	}
+	require.Equal(t, "apm", attrs["sw.data.module"])
+	require.Equal(t, "test-log-stream", attrs["faas.instance"])
+}

--- a/swo/agent_test.go
+++ b/swo/agent_test.go
@@ -54,9 +54,9 @@ func TestSetLogOutput(t *testing.T) {
 	}()
 
 	var buf utils.SafeBuffer
-	log.SetOutput(&buf)
+	SetLogOutput(&buf)
 	defer func() {
-		log.SetOutput(os.Stderr)
+		SetLogOutput(os.Stderr)
 	}()
 
 	log.Info("hello world")

--- a/swo/log_test.go
+++ b/swo/log_test.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"testing"
 	"time"
+	// "fmt"
 )
 
 func TestLoggableTraceIDFromContext(t *testing.T) {
@@ -151,4 +152,39 @@ func TestHandle(t *testing.T) {
 
 		})
 	}
+}
+
+func TestLogHandlerEnabled(t *testing.T) {
+	baseHandler := slog.NewJSONHandler(bytes.NewBuffer(nil), &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})
+	handler := NewLogHandler(baseHandler)
+
+	require.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	require.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	require.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestLogHandlerWithAttrs(t *testing.T) {
+	writer := bytes.NewBuffer(nil)
+	baseHandler := slog.NewJSONHandler(writer, &slog.HandlerOptions{})
+	handler := NewLogHandler(baseHandler)
+	attrHandler := handler.WithAttrs([]slog.Attr{slog.String("key", "value")})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	require.NoError(t, attrHandler.Handle(context.Background(), record))
+	require.Contains(t, writer.String(), `"msg":"test"`)
+	require.Contains(t, writer.String(), `"key":"value"`)
+}
+
+func TestLogHandlerWithGroup(t *testing.T) {
+	writer := bytes.NewBuffer(nil)
+	baseHandler := slog.NewJSONHandler(writer, &slog.HandlerOptions{})
+	handler := NewLogHandler(baseHandler)
+	groupHandler := handler.WithGroup("mygroup")
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	require.NoError(t, groupHandler.Handle(context.Background(), record))
+	require.Contains(t, writer.String(), `"msg":"test"`)
+	require.Contains(t, writer.String(), "mygroup")
 }

--- a/swo/log_test.go
+++ b/swo/log_test.go
@@ -24,7 +24,6 @@ import (
 	"log/slog"
 	"testing"
 	"time"
-	// "fmt"
 )
 
 func TestLoggableTraceIDFromContext(t *testing.T) {


### PR DESCRIPTION
## Description

False positive from `deadcode`
```
instrumentation/net/http/swohttp/handler.go:36:6: unreachable func: WrapBaseHandler
swo/agent_api.go:50:6: unreachable func: SetLogOutput
swo/agent_lambda.go:47:24: unreachable func: lambdaFlusher.Flush
swo/agent_lambda.go:53:6: unreachable func: StartLambda
swo/log.go:77:22: unreachable func: LogHandler.Enabled
swo/log.go:99:22: unreachable func: LogHandler.WithAttrs
swo/log.go:104:22: unreachable func: LogHandler.WithGroup
```
Removing these signal by adding the test case for these api calls.