### PR TITLE
align release tag and version

### DIFF
--- a/internal/utils/version.go
+++ b/internal/utils/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	baseVersion = "1.3.0"
+	baseVersion = "1.3.2"
 	prerelease  = ""
 	build       = ""
 


### PR DESCRIPTION
Release 1.3.1 is not aligned with version.go.
Making additional release 1.3.2 to fix that mistake.