### PR TITLE
NH-132624: re-enable SW_APM_RUNTIME_METRICS config

### DIFF
--- a/internal/reporter/metrics_publisher.go
+++ b/internal/reporter/metrics_publisher.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/solarwinds/apm-go/internal/config"
 	"github.com/solarwinds/apm-go/internal/metrics"
 	"github.com/solarwinds/apm-go/internal/oboe"
 	"github.com/solarwinds/apm-go/internal/otelsetup"
@@ -50,8 +51,10 @@ func (c *MetricsPublisher) ConfigureAndStart(ctx context.Context, o oboe.Oboe, r
 		return err
 	}
 	// Register OpenTelemetry contrib runtime metrics
-	if err = runtime.Start(runtime.WithMeterProvider(meterProvider)); err != nil {
-		return err
+	if config.GetRuntimeMetrics() {
+		if err = runtime.Start(runtime.WithMeterProvider(meterProvider)); err != nil {
+			return err
+		}
 	}
 	otel.SetMeterProvider(meterProvider)
 


### PR DESCRIPTION
## Description

`SW_APM_RUNTIME_METRICS` determine whether runtime metrics is enabled or not.

## Test

[Service](https://my.na-01.st-ssp.solarwinds.com/136444677275740160/entities/services/e-7856251025755195104/service-metrics?duration=3600&view=table) with `SW_APM_RUNTIME_METRICS=false`
