### PR TITLE
NH-106182: support disabling runtime metrics and added producer for go.schedule.duration

### DIFF
--- a/internal/reporter/metrics_publisher.go
+++ b/internal/reporter/metrics_publisher.go
@@ -37,21 +37,32 @@ func NewMetricsPublisher() *MetricsPublisher {
 	return &MetricsPublisher{}
 }
 
+func newMeterProvider(otelMetricExporter metric.Exporter, resource *sdkresource.Resource, runtimeMetrics bool) *metric.MeterProvider {
+	readerOpts := []metric.PeriodicReaderOption{metric.WithInterval(1 * time.Minute)}
+	if runtimeMetrics {
+		readerOpts = append(readerOpts, metric.WithProducer(runtime.NewProducer()))
+	}
+
+	return metric.NewMeterProvider(
+		metric.WithReader(metric.NewPeriodicReader(otelMetricExporter, readerOpts...)),
+		metric.WithResource(resource),
+	)
+}
+
 func (c *MetricsPublisher) ConfigureAndStart(ctx context.Context, o oboe.Oboe, resource *sdkresource.Resource) error {
 	otelMetricExporter, err := otelsetup.CreateAndSetupOtelMetricsExporter(ctx)
 	if err != nil {
 		return err
 	}
-	meterProvider := metric.NewMeterProvider(
-		metric.WithReader(metric.NewPeriodicReader(otelMetricExporter,
-			metric.WithInterval(1*time.Minute))),
-		metric.WithResource(resource),
-	)
+
+	runtimeMetricsEnabled := config.GetRuntimeMetrics()
+	meterProvider := newMeterProvider(otelMetricExporter, resource, runtimeMetricsEnabled)
+
 	if err = o.RegisterOtelSampleRateMetrics(meterProvider); err != nil {
 		return err
 	}
 	// Register OpenTelemetry contrib runtime metrics
-	if config.GetRuntimeMetrics() {
+	if runtimeMetricsEnabled {
 		if err = runtime.Start(runtime.WithMeterProvider(meterProvider)); err != nil {
 			return err
 		}

--- a/internal/reporter/metrics_publisher_test.go
+++ b/internal/reporter/metrics_publisher_test.go
@@ -15,9 +15,12 @@
 package reporter
 
 import (
+	"context"
 	"testing"
 
+	"github.com/solarwinds/apm-go/internal/testutils"
 	"github.com/stretchr/testify/require"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 )
 
 func TestNewMetricsPublisher(t *testing.T) {
@@ -36,4 +39,24 @@ func TestMetricsPublisherShutdownWhenNotConfigured(t *testing.T) {
 	p := NewMetricsPublisher()
 
 	require.NoError(t, p.Shutdown())
+}
+
+func TestNewMeterProvider(t *testing.T) {
+	exporter := testutils.NewTestMetricExporter()
+
+	testCases := []struct {
+		name           string
+		runtimeMetrics bool
+	}{
+		{name: "runtime metrics disabled", runtimeMetrics: false},
+		{name: "runtime metrics enabled", runtimeMetrics: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			meterProvider := newMeterProvider(exporter, sdkresource.Empty(), tc.runtimeMetrics)
+			require.NotNil(t, meterProvider)
+			require.NoError(t, meterProvider.Shutdown(context.Background()))
+		})
+	}
 }

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -26,6 +26,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -131,4 +133,31 @@ func WriteUUIDFile(t *testing.T, id uuid.UUID) string {
 // endpoint format with the given UUID as the uamsclient_id.
 func UamsClientResponse(id uuid.UUID) string {
 	return fmt.Sprintf(`{"is_registered":true,"otel_endpoint_access":false,"usc_connectivity":true,"uamsclient_id":"%s"}`, id.String())
+}
+
+// NewTestMetricExporter returns a no-op OpenTelemetry metric exporter for tests.
+func NewTestMetricExporter() metric.Exporter {
+	return testMetricExporter{}
+}
+
+type testMetricExporter struct{}
+
+func (testMetricExporter) Temporality(k metric.InstrumentKind) metricdata.Temporality {
+	return metric.DefaultTemporalitySelector(k)
+}
+
+func (testMetricExporter) Aggregation(k metric.InstrumentKind) metric.Aggregation {
+	return metric.DefaultAggregationSelector(k)
+}
+
+func (testMetricExporter) Export(context.Context, *metricdata.ResourceMetrics) error {
+	return nil
+}
+
+func (testMetricExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+func (testMetricExporter) Shutdown(context.Context) error {
+	return nil
 }


### PR DESCRIPTION
## Description

- integrated the runtime metrics producer for `go.schedule.duration`
- for `go.memory.limit`, nothing to change, just need to set `GOMEMLIMIT=1GiB` to see it.

Sample dashboard
https://my.na-01.st-ssp.solarwinds.com/136444677275740160/dashboards/119755?duration=86400&play=0&endTime=1777394629
