### PR TITLE
NH-141747: Fix incorrect sampling settings when service name is overridden

### DIFF
--- a/internal/oboe/settings_http_updater.go
+++ b/internal/oboe/settings_http_updater.go
@@ -39,7 +39,7 @@ type SettingsUpdater interface {
 	Start(ctx context.Context) func()
 }
 
-func NewSettingsUpdater(o Oboe) (SettingsUpdater, error) {
+func NewSettingsUpdater(o Oboe, serviceName string) (SettingsUpdater, error) {
 	if !config.GetEnabled() {
 		log.Info("SolarWinds Observability APM agent is disabled. Settings are not polled from the server.")
 		return newNullSettingsUpdater(), nil
@@ -56,7 +56,7 @@ func NewSettingsUpdater(o Oboe) (SettingsUpdater, error) {
 		updateInterval:   defaultSettingsUpdateInterval,
 		ttlCheckInterval: defaultSettingsTTLCheckInterval,
 		oboe:             o,
-		settingsService:  newSettingsService(settingsUrl, parsedServiceKey.ServiceName, "", parsedServiceKey.Token),
+		settingsService:  newSettingsService(settingsUrl, serviceName, "", parsedServiceKey.Token),
 	}, nil
 }
 

--- a/internal/oboe/settings_http_updater_test.go
+++ b/internal/oboe/settings_http_updater_test.go
@@ -71,7 +71,7 @@ func TestSettingsUpdater_QueriesAndUpdatesSettings(t *testing.T) {
 	)
 
 	o := NewOboe()
-	updater, err := NewSettingsUpdater(o)
+	updater, err := NewSettingsUpdater(o, serviceName)
 	require.NoError(t, err)
 	require.NotNil(t, updater)
 

--- a/swo/agent.go
+++ b/swo/agent.go
@@ -30,7 +30,9 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // Start bootstraps otel requirements and starts the agent. The given `resourceAttrs` are added to the otel
@@ -47,9 +49,12 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 			// return a no-op func so that we don't cause a nil-deref for the end-user
 		}, err
 	}
-	o := oboe.NewOboe()
+	// createResource determines the final service.name; read it back here so the
+	// settings API call uses the same name that appears on spans.
+	svcName := serviceNameFromResource(resrc)
 
-	settingsUpdater, err := oboe.NewSettingsUpdater(o)
+	o := oboe.NewOboe()
+	settingsUpdater, err := oboe.NewSettingsUpdater(o, svcName)
 	if err != nil {
 		log.Error("Failed to create settings updater, ", err)
 		return func() {}, err
@@ -102,4 +107,9 @@ func Start(resourceAttrs ...attribute.KeyValue) (func(), error) {
 			stdlog.Fatal(err)
 		}
 	}, nil
+}
+
+func serviceNameFromResource(resrc *resource.Resource) string {
+	val, _ := resrc.Set().Value(semconv.ServiceNameKey)
+	return val.AsString()
 }

--- a/swo/agent_test.go
+++ b/swo/agent_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -104,6 +105,66 @@ func TestSetTransactionName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "this should work", entryspans.GetTransactionName(s.SpanContext().TraceID()))
 
+}
+
+func TestServiceNameFromResource(t *testing.T) {
+	t.Run("returns service.name when present", func(t *testing.T) {
+		r := resource.NewSchemaless(attribute.String("service.name", "resource-service-name"))
+		assert.Equal(t, "resource-service-name", serviceNameFromResource(r))
+	})
+
+	t.Run("returns empty string when service.name absent", func(t *testing.T) {
+		r := resource.NewSchemaless(attribute.String("some.other.attr", "value"))
+		assert.Equal(t, "", serviceNameFromResource(r))
+	})
+}
+
+func TestServiceNamePrecedence(t *testing.T) {
+	const (
+		validKey         = "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:key-service-name"
+		disableDetectors = "ec2,azurevm,uams"
+	)
+
+	tests := []struct {
+		name         string
+		envSvcName   string
+		resourceAttr string
+		want         string
+	}{
+		{
+			name: "service key is baseline",
+			want: "key-service-name",
+		},
+		{
+			name:       "OTEL_SERVICE_NAME overrides service key",
+			envSvcName: "env-service-name",
+			want:       "env-service-name",
+		},
+		{
+			name:         "resourceAttr overrides OTEL_SERVICE_NAME",
+			envSvcName:   "env-service-name",
+			resourceAttr: "api-service-name",
+			want:         "api-service-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() { config.Load() })
+			t.Setenv("SW_APM_SERVICE_KEY", validKey)
+			t.Setenv("OTEL_SERVICE_NAME", tt.envSvcName)
+			t.Setenv("SW_APM_DISABLED_RESOURCE_DETECTORS", disableDetectors)
+			config.Load()
+
+			var attrs []attribute.KeyValue
+			if tt.resourceAttr != "" {
+				attrs = append(attrs, attribute.String("service.name", tt.resourceAttr))
+			}
+			r, err := createResource(attrs...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, serviceNameFromResource(r))
+		})
+	}
 }
 
 func TestStartDisabled(t *testing.T) {


### PR DESCRIPTION
The settings HTTP poller was using the service name from the service key token, ignoring any service name set via semconv.ServiceName(). This caused sampling settings to be fetched for the wrong service.