### PR TITLE
chore: one pr for all action-related dependencies update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Github action dep update rarely cause conflict so make dependabot create the single pr to update them all (similar to renovate)